### PR TITLE
Implement sleep timer

### DIFF
--- a/lib/screens/channel/stores/video_store.g.dart
+++ b/lib/screens/channel/stores/video_store.g.dart
@@ -17,6 +17,51 @@ mixin _$VideoStore on _VideoStoreBase, Store {
               name: '_VideoStoreBase.videoUrl'))
           .value;
 
+  final _$sleepHoursAtom = Atom(name: '_VideoStoreBase.sleepHours');
+
+  @override
+  int get sleepHours {
+    _$sleepHoursAtom.reportRead();
+    return super.sleepHours;
+  }
+
+  @override
+  set sleepHours(int value) {
+    _$sleepHoursAtom.reportWrite(value, super.sleepHours, () {
+      super.sleepHours = value;
+    });
+  }
+
+  final _$sleepMinutesAtom = Atom(name: '_VideoStoreBase.sleepMinutes');
+
+  @override
+  int get sleepMinutes {
+    _$sleepMinutesAtom.reportRead();
+    return super.sleepMinutes;
+  }
+
+  @override
+  set sleepMinutes(int value) {
+    _$sleepMinutesAtom.reportWrite(value, super.sleepMinutes, () {
+      super.sleepMinutes = value;
+    });
+  }
+
+  final _$timeRemainingAtom = Atom(name: '_VideoStoreBase.timeRemaining');
+
+  @override
+  Duration get timeRemaining {
+    _$timeRemainingAtom.reportRead();
+    return super.timeRemaining;
+  }
+
+  @override
+  set timeRemaining(Duration value) {
+    _$timeRemainingAtom.reportWrite(value, super.timeRemaining, () {
+      super.timeRemaining = value;
+    });
+  }
+
   final _$_pausedAtom = Atom(name: '_VideoStoreBase._paused');
 
   bool get paused {
@@ -124,6 +169,9 @@ mixin _$VideoStore on _VideoStoreBase, Store {
   @override
   String toString() {
     return '''
+sleepHours: ${sleepHours},
+sleepMinutes: ${sleepMinutes},
+timeRemaining: ${timeRemaining},
 videoUrl: ${videoUrl}
     ''';
   }

--- a/lib/screens/channel/video/video_overlay.dart
+++ b/lib/screens/channel/video/video_overlay.dart
@@ -78,8 +78,14 @@ class VideoOverlay extends StatelessWidget {
     if (streamInfo == null) {
       return Stack(
         children: [
-          backButton,
-          settingsButton,
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              backButton,
+              const Spacer(),
+              settingsButton,
+            ],
+          ),
           Align(
             alignment: Alignment.bottomRight,
             child: Row(

--- a/lib/screens/channel/video/video_overlay.dart
+++ b/lib/screens/channel/video/video_overlay.dart
@@ -8,11 +8,16 @@ import 'package:frosty/screens/channel/stores/video_store.dart';
 import 'package:frosty/screens/settings/settings.dart';
 import 'package:intl/intl.dart';
 
-class VideoOverlay extends StatelessWidget {
+class VideoOverlay extends StatefulWidget {
   final VideoStore videoStore;
 
   const VideoOverlay({Key? key, required this.videoStore}) : super(key: key);
 
+  @override
+  State<VideoOverlay> createState() => _VideoOverlayState();
+}
+
+class _VideoOverlayState extends State<VideoOverlay> {
   Future<void> _showSleepTimerDialog(BuildContext context) {
     return showDialog(
       context: context,
@@ -23,12 +28,11 @@ class VideoOverlay extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: [
               Row(
-                mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   DropdownButton(
-                    value: videoStore.sleepHours,
+                    value: widget.videoStore.sleepHours,
                     items: List.generate(24, (index) => index).map((e) => DropdownMenuItem(value: e, child: Text(e.toString()))).toList(),
-                    onChanged: (int? hours) => videoStore.sleepHours = hours!,
+                    onChanged: (int? hours) => widget.videoStore.sleepHours = hours!,
                     menuMaxHeight: 200,
                   ),
                   const SizedBox(width: 10.0),
@@ -36,28 +40,29 @@ class VideoOverlay extends StatelessWidget {
                 ],
               ),
               Row(
-                mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   DropdownButton(
-                    value: videoStore.sleepMinutes,
+                    value: widget.videoStore.sleepMinutes,
                     items: List.generate(60, (index) => index).map((e) => DropdownMenuItem(value: e, child: Text(e.toString()))).toList(),
-                    onChanged: (int? minutes) => videoStore.sleepMinutes = minutes!,
+                    onChanged: (int? minutes) => widget.videoStore.sleepMinutes = minutes!,
                     menuMaxHeight: 200,
                   ),
                   const SizedBox(width: 10.0),
                   const Text('Minutes'),
                 ],
               ),
-              Row(
-                children: [
-                  Text('Timer: ${videoStore.timeRemaining.toString().split('.')[0]}'),
-                  const Spacer(),
-                  IconButton(
-                    onPressed: videoStore.cancelSleepTimer,
-                    icon: const Icon(Icons.cancel),
-                  ),
-                ],
-              ),
+              if (widget.videoStore.sleepTimer != null && widget.videoStore.sleepTimer!.isActive)
+                Row(
+                  children: [
+                    Text('Timer: ${widget.videoStore.timeRemaining.toString().split('.')[0]}'),
+                    const Spacer(),
+                    IconButton(
+                      tooltip: 'Cancel Timer',
+                      onPressed: widget.videoStore.cancelSleepTimer,
+                      icon: const Icon(Icons.cancel),
+                    ),
+                  ],
+                ),
             ],
           ),
         ),
@@ -66,10 +71,12 @@ class VideoOverlay extends StatelessWidget {
             onPressed: Navigator.of(context).pop,
             child: const Text('Close'),
           ),
-          TextButton(
-            onPressed: videoStore.updateSleepTimer,
-            child: const Text('Set Timer'),
-            style: TextButton.styleFrom(primary: Colors.green),
+          Observer(
+            builder: (context) => TextButton(
+              onPressed: widget.videoStore.sleepHours == 0 && widget.videoStore.sleepMinutes == 0 ? null : widget.videoStore.updateSleepTimer,
+              child: const Text('Set Timer'),
+              style: TextButton.styleFrom(primary: Colors.green),
+            ),
           ),
         ],
       ),
@@ -103,7 +110,7 @@ class VideoOverlay extends StatelessWidget {
         context: context,
         builder: (context) => SizedBox(
           height: MediaQuery.of(context).size.height * 0.8,
-          child: Settings(settingsStore: videoStore.settingsStore),
+          child: Settings(settingsStore: widget.videoStore.settingsStore),
         ),
       ),
     );
@@ -114,12 +121,12 @@ class VideoOverlay extends StatelessWidget {
         Icons.refresh,
         color: Colors.white,
       ),
-      onPressed: videoStore.handleRefresh,
+      onPressed: widget.videoStore.handleRefresh,
     );
 
     final fullScreenButton = IconButton(
-      tooltip: videoStore.settingsStore.fullScreen ? 'Exit Fullscreen' : 'Enter Fullscreen',
-      icon: videoStore.settingsStore.fullScreen
+      tooltip: widget.videoStore.settingsStore.fullScreen ? 'Exit Fullscreen' : 'Enter Fullscreen',
+      icon: widget.videoStore.settingsStore.fullScreen
           ? const Icon(
               Icons.fullscreen_exit,
               color: Colors.white,
@@ -128,7 +135,7 @@ class VideoOverlay extends StatelessWidget {
               Icons.fullscreen,
               color: Colors.white,
             ),
-      onPressed: () => videoStore.settingsStore.fullScreen = !videoStore.settingsStore.fullScreen,
+      onPressed: () => widget.videoStore.settingsStore.fullScreen = !widget.videoStore.settingsStore.fullScreen,
     );
 
     final sleepTimerButton = IconButton(
@@ -137,7 +144,7 @@ class VideoOverlay extends StatelessWidget {
       onPressed: () => _showSleepTimerDialog(context),
     );
 
-    final streamInfo = videoStore.streamInfo;
+    final streamInfo = widget.videoStore.streamInfo;
 
     if (streamInfo == null) {
       return Stack(
@@ -190,9 +197,9 @@ class VideoOverlay extends StatelessWidget {
           if (Platform.isAndroid)
             Center(
               child: IconButton(
-                tooltip: videoStore.paused ? 'Play' : 'Pause',
+                tooltip: widget.videoStore.paused ? 'Play' : 'Pause',
                 iconSize: 50.0,
-                icon: videoStore.paused
+                icon: widget.videoStore.paused
                     ? const Icon(
                         Icons.play_arrow,
                         color: Colors.white,
@@ -201,10 +208,10 @@ class VideoOverlay extends StatelessWidget {
                         Icons.pause,
                         color: Colors.white,
                       ),
-                onPressed: videoStore.handlePausePlay,
+                onPressed: widget.videoStore.handlePausePlay,
               ),
             )
-          else if (!videoStore.paused)
+          else if (!widget.videoStore.paused)
             Center(
               child: IconButton(
                 tooltip: 'Pause',
@@ -213,7 +220,7 @@ class VideoOverlay extends StatelessWidget {
                   Icons.pause,
                   color: Colors.white,
                 ),
-                onPressed: videoStore.handlePausePlay,
+                onPressed: widget.videoStore.handlePausePlay,
               ),
             ),
           Align(
@@ -223,10 +230,10 @@ class VideoOverlay extends StatelessWidget {
               children: [
                 Expanded(
                   child: GestureDetector(
-                    onTap: videoStore.handleExpand,
+                    onTap: widget.videoStore.handleExpand,
                     child: Padding(
                       padding: const EdgeInsets.all(10.0),
-                      child: videoStore.settingsStore.expandInfo
+                      child: widget.videoStore.settingsStore.expandInfo
                           ? Column(
                               mainAxisAlignment: MainAxisAlignment.end,
                               crossAxisAlignment: CrossAxisAlignment.start,
@@ -234,11 +241,11 @@ class VideoOverlay extends StatelessWidget {
                                 streamer,
                                 const SizedBox(height: 5.0),
                                 Tooltip(
-                                  message: videoStore.streamInfo!.title.trim(),
+                                  message: widget.videoStore.streamInfo!.title.trim(),
                                   preferBelow: false,
                                   padding: const EdgeInsets.all(10.0),
                                   child: Text(
-                                    videoStore.streamInfo!.title.trim(),
+                                    widget.videoStore.streamInfo!.title.trim(),
                                     maxLines: orientation == Orientation.portrait ? 1 : 5,
                                     overflow: TextOverflow.ellipsis,
                                     style: const TextStyle(
@@ -248,7 +255,7 @@ class VideoOverlay extends StatelessWidget {
                                 ),
                                 const SizedBox(height: 5.0),
                                 Text(
-                                  '${videoStore.streamInfo?.gameName} for ${NumberFormat().format(videoStore.streamInfo?.viewerCount)} viewers',
+                                  '${widget.videoStore.streamInfo?.gameName} for ${NumberFormat().format(widget.videoStore.streamInfo?.viewerCount)} viewers',
                                   style: const TextStyle(
                                     color: Colors.white,
                                   ),
@@ -260,14 +267,14 @@ class VideoOverlay extends StatelessWidget {
                   ),
                 ),
                 refreshButton,
-                if (Platform.isIOS && videoStore.settingsStore.pictureInPicture)
+                if (Platform.isIOS && widget.videoStore.settingsStore.pictureInPicture)
                   IconButton(
                     tooltip: 'Picture-in-Picture',
                     icon: const Icon(
                       Icons.picture_in_picture_alt_rounded,
                       color: Colors.white,
                     ),
-                    onPressed: videoStore.requestPictureInPicture,
+                    onPressed: widget.videoStore.requestPictureInPicture,
                   ),
                 if (orientation == Orientation.landscape) fullScreenButton
               ],
@@ -276,5 +283,11 @@ class VideoOverlay extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  @override
+  void dispose() {
+    widget.videoStore.cancelSleepTimer();
+    super.dispose();
   }
 }

--- a/lib/screens/channel/video/video_overlay.dart
+++ b/lib/screens/channel/video/video_overlay.dart
@@ -28,21 +28,18 @@ class VideoOverlay extends StatelessWidget {
       ),
     );
 
-    final settingsButton = Align(
-      alignment: Alignment.topRight,
-      child: IconButton(
-        tooltip: 'Settings',
-        icon: const Icon(
-          Icons.settings,
-          color: Colors.white,
-        ),
-        onPressed: () => showModalBottomSheet(
-          isScrollControlled: true,
-          context: context,
-          builder: (context) => SizedBox(
-            height: MediaQuery.of(context).size.height * 0.8,
-            child: Settings(settingsStore: videoStore.settingsStore),
-          ),
+    final settingsButton = IconButton(
+      tooltip: 'Settings',
+      icon: const Icon(
+        Icons.settings,
+        color: Colors.white,
+      ),
+      onPressed: () => showModalBottomSheet(
+        isScrollControlled: true,
+        context: context,
+        builder: (context) => SizedBox(
+          height: MediaQuery.of(context).size.height * 0.8,
+          child: Settings(settingsStore: videoStore.settingsStore),
         ),
       ),
     );
@@ -68,6 +65,12 @@ class VideoOverlay extends StatelessWidget {
               color: Colors.white,
             ),
       onPressed: () => videoStore.settingsStore.fullScreen = !videoStore.settingsStore.fullScreen,
+    );
+
+    final sleepTimerButton = IconButton(
+      tooltip: 'Sleep Timer',
+      icon: const Icon(Icons.timer),
+      onPressed: () {},
     );
 
     final streamInfo = videoStore.streamInfo;
@@ -103,8 +106,15 @@ class VideoOverlay extends StatelessWidget {
     return Observer(
       builder: (context) => Stack(
         children: [
-          backButton,
-          settingsButton,
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              backButton,
+              const Spacer(),
+              sleepTimerButton,
+              settingsButton,
+            ],
+          ),
           // Add a play button when paused for Android
           // When an ad is paused on Android there is no way to unpause, so a play button is necessary.
           if (Platform.isAndroid)

--- a/lib/screens/channel/video/video_overlay.dart
+++ b/lib/screens/channel/video/video_overlay.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -11,6 +12,69 @@ class VideoOverlay extends StatelessWidget {
   final VideoStore videoStore;
 
   const VideoOverlay({Key? key, required this.videoStore}) : super(key: key);
+
+  Future<void> _showSleepTimerDialog(BuildContext context) {
+    return showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Sleep Timer'),
+        content: Observer(
+          builder: (context) => Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  DropdownButton(
+                    value: videoStore.sleepHours,
+                    items: List.generate(24, (index) => index).map((e) => DropdownMenuItem(value: e, child: Text(e.toString()))).toList(),
+                    onChanged: (int? hours) => videoStore.sleepHours = hours!,
+                    menuMaxHeight: 200,
+                  ),
+                  const SizedBox(width: 10.0),
+                  const Text('Hours'),
+                ],
+              ),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  DropdownButton(
+                    value: videoStore.sleepMinutes,
+                    items: List.generate(60, (index) => index).map((e) => DropdownMenuItem(value: e, child: Text(e.toString()))).toList(),
+                    onChanged: (int? minutes) => videoStore.sleepMinutes = minutes!,
+                    menuMaxHeight: 200,
+                  ),
+                  const SizedBox(width: 10.0),
+                  const Text('Minutes'),
+                ],
+              ),
+              Row(
+                children: [
+                  Text('Timer: ${videoStore.timeRemaining.toString().split('.')[0]}'),
+                  const Spacer(),
+                  IconButton(
+                    onPressed: videoStore.cancelSleepTimer,
+                    icon: const Icon(Icons.cancel),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: Navigator.of(context).pop,
+            child: const Text('Close'),
+          ),
+          TextButton(
+            onPressed: videoStore.updateSleepTimer,
+            child: const Text('Set Timer'),
+            style: TextButton.styleFrom(primary: Colors.green),
+          ),
+        ],
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -70,7 +134,7 @@ class VideoOverlay extends StatelessWidget {
     final sleepTimerButton = IconButton(
       tooltip: 'Sleep Timer',
       icon: const Icon(Icons.timer),
-      onPressed: () {},
+      onPressed: () => _showSleepTimerDialog(context),
     );
 
     final streamInfo = videoStore.streamInfo;


### PR DESCRIPTION
This PR adds a sleep timer accessible through an icon button on the video overlay. The user is able to set their desired hours and/or minutes which will then initiate a cancellable countdown. When this countdown reaches zero, the app will exit and let the user's system sleep setting take over.

Closes #79