### PR TITLE
Use pop instead of exit for sleep timer

### DIFF
--- a/lib/screens/channel/stores/video_store.dart
+++ b/lib/screens/channel/stores/video_store.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -164,7 +163,8 @@ abstract class _VideoStoreBase with Store {
   }
 
   /// Updates the sleep timer with [sleepHours] and [sleepMinutes].
-  void updateSleepTimer() {
+  /// Calls [onTimerFinished] when the sleep timer completes.
+  void updateSleepTimer({required void Function() onTimerFinished}) {
     // If hours and minutes are 0, do nothing.
     if (sleepHours == 0 && sleepMinutes == 0) return;
 
@@ -185,7 +185,7 @@ abstract class _VideoStoreBase with Store {
         // If the timer is up, cancel the timer and exit the app.
         if (timeRemaining.inSeconds == 0) {
           timer.cancel();
-          Platform.isIOS ? exit(0) : SystemNavigator.pop();
+          onTimerFinished();
           return;
         }
 

--- a/lib/screens/channel/video/video_overlay.dart
+++ b/lib/screens/channel/video/video_overlay.dart
@@ -18,7 +18,7 @@ class VideoOverlay extends StatefulWidget {
 }
 
 class _VideoOverlayState extends State<VideoOverlay> {
-  Future<void> _showSleepTimerDialog(BuildContext context) {
+  Future<void> _showSleepTimerDialog(BuildContext oldContext) {
     return showDialog(
       context: context,
       builder: (context) => AlertDialog(
@@ -69,11 +69,18 @@ class _VideoOverlayState extends State<VideoOverlay> {
         actions: [
           TextButton(
             onPressed: Navigator.of(context).pop,
-            child: const Text('Close'),
+            child: const Text('Dismiss'),
           ),
           Observer(
             builder: (context) => TextButton(
-              onPressed: widget.videoStore.sleepHours == 0 && widget.videoStore.sleepMinutes == 0 ? null : widget.videoStore.updateSleepTimer,
+              onPressed: widget.videoStore.sleepHours == 0 && widget.videoStore.sleepMinutes == 0
+                  ? null
+                  : () => widget.videoStore.updateSleepTimer(
+                        onTimerFinished: () => Navigator.popUntil(
+                          oldContext,
+                          (route) => route.isFirst,
+                        ),
+                      ),
               child: const Text('Set Timer'),
               style: TextButton.styleFrom(primary: Colors.green),
             ),
@@ -140,7 +147,10 @@ class _VideoOverlayState extends State<VideoOverlay> {
 
     final sleepTimerButton = IconButton(
       tooltip: 'Sleep Timer',
-      icon: const Icon(Icons.timer),
+      icon: const Icon(
+        Icons.timer,
+        color: Colors.white,
+      ),
       onPressed: () => _showSleepTimerDialog(context),
     );
 


### PR DESCRIPTION
Apple probably won't approve of exiting the app programmatically based on their guidelines, so going ahead with pop like other apps.