### PR TITLE
Fix FFZ/7TV emotes on certain channels

### DIFF
--- a/lib/api/ffz_api.dart
+++ b/lib/api/ffz_api.dart
@@ -33,8 +33,8 @@ class FFZApi {
   }
 
   /// Returns a channel's FFZ room info including custom badges and emote used.
-  Future<Tuple2<RoomFFZ, List<Emote>>> getRoomInfo({required String name}) async {
-    final url = Uri.parse('https://api.frankerfacez.com/v1/room/$name');
+  Future<Tuple2<RoomFFZ, List<Emote>>> getRoomInfo({required String id}) async {
+    final url = Uri.parse('https://api.frankerfacez.com/v1/room/id/$id');
 
     final response = await _client.get(url);
     if (response.statusCode == 200) {

--- a/lib/api/seventv_api.dart
+++ b/lib/api/seventv_api.dart
@@ -26,8 +26,8 @@ class SevenTVApi {
   }
 
   /// Returns a map of a channel's 7TV emotes to their URL.
-  Future<List<Emote>> getEmotesChannel({required String user}) async {
-    final url = Uri.parse('https://api.7tv.app/v2/users/$user/emotes');
+  Future<List<Emote>> getEmotesChannel({required String id}) async {
+    final url = Uri.parse('https://api.7tv.app/v2/users/$id/emotes');
 
     final response = await _client.get(url);
     if (response.statusCode == 200) {

--- a/lib/screens/channel/stores/chat_assets_store.dart
+++ b/lib/screens/channel/stores/chat_assets_store.dart
@@ -103,7 +103,6 @@ abstract class ChatAssetsStoreBase with Store {
   /// Fetches global and channel assets (badges and emotes) and stores them in [_emoteToUrl]
   @action
   Future<void> assetsFuture({
-    required String channelName,
     required String channelId,
     required Map<String, String> headers,
     required Function onEmoteError,
@@ -113,7 +112,6 @@ abstract class ChatAssetsStoreBase with Store {
       // Async awaits are placed in a list so they are performed in parallel.
       Future.wait([
         emotesFuture(
-          channelName: channelName,
           channelId: channelId,
           headers: headers,
           onError: onEmoteError,
@@ -128,7 +126,6 @@ abstract class ChatAssetsStoreBase with Store {
   @action
   Future<void> emotesFuture({
     required String channelId,
-    required String channelName,
     required Map<String, String> headers,
     required Function onError,
   }) =>
@@ -142,8 +139,8 @@ abstract class ChatAssetsStoreBase with Store {
         twitchApi.getEmotesGlobal(headers: headers).catchError(onError),
         twitchApi.getEmotesChannel(id: channelId, headers: headers).catchError(onError),
         sevenTVApi.getEmotesGlobal().catchError(onError),
-        sevenTVApi.getEmotesChannel(user: channelName).catchError(onError),
-        ffzApi.getRoomInfo(name: channelName).then((ffzRoom) {
+        sevenTVApi.getEmotesChannel(id: channelId).catchError(onError),
+        ffzApi.getRoomInfo(id: channelId).then((ffzRoom) {
           ffzRoomInfo = ffzRoom.item1;
           return ffzRoom.item2;
         }).catchError(onError),

--- a/lib/screens/channel/stores/chat_assets_store.g.dart
+++ b/lib/screens/channel/stores/chat_assets_store.g.dart
@@ -184,8 +184,7 @@ mixin _$ChatAssetsStore on ChatAssetsStoreBase, Store {
 
   @override
   Future<void> assetsFuture(
-      {required String channelName,
-      required String channelId,
+      {required String channelId,
       required Map<String, String> headers,
       required Function onEmoteError,
       required Function onBadgeError}) {
@@ -193,7 +192,6 @@ mixin _$ChatAssetsStore on ChatAssetsStoreBase, Store {
         name: 'ChatAssetsStoreBase.assetsFuture');
     try {
       return super.assetsFuture(
-          channelName: channelName,
           channelId: channelId,
           headers: headers,
           onEmoteError: onEmoteError,
@@ -206,17 +204,13 @@ mixin _$ChatAssetsStore on ChatAssetsStoreBase, Store {
   @override
   Future<void> emotesFuture(
       {required String channelId,
-      required String channelName,
       required Map<String, String> headers,
       required Function onError}) {
     final _$actionInfo = _$ChatAssetsStoreBaseActionController.startAction(
         name: 'ChatAssetsStoreBase.emotesFuture');
     try {
       return super.emotesFuture(
-          channelId: channelId,
-          channelName: channelName,
-          headers: headers,
-          onError: onError);
+          channelId: channelId, headers: headers, onError: onError);
     } finally {
       _$ChatAssetsStoreBaseActionController.endAction(_$actionInfo);
     }

--- a/lib/screens/channel/stores/chat_store.dart
+++ b/lib/screens/channel/stores/chat_store.dart
@@ -206,7 +206,6 @@ abstract class ChatStoreBase with Store {
 
         // Fetch the assets used in chat including badges and emotes.
         assetsStore.assetsFuture(
-          channelName: channelName,
           channelId: channelId,
           headers: auth.headersTwitch,
           onEmoteError: (error) {


### PR DESCRIPTION
When a channel changes their name, FFZ/7TV emote endpoints for the channel name are not updated immediately. This PR will utilize the channel's persistent id to check for emotes instead.

Fixes #115