### PR TITLE
Improve sorting for subscribed emotes in emote menu

### DIFF
--- a/lib/models/emotes.dart
+++ b/lib/models/emotes.dart
@@ -264,6 +264,7 @@ class Emote {
   final bool zeroWidth;
   final String url;
   final EmoteType type;
+  final String? ownerId;
 
   const Emote({
     required this.name,
@@ -272,6 +273,7 @@ class Emote {
     required this.zeroWidth,
     required this.url,
     required this.type,
+    this.ownerId,
   });
 
   factory Emote.fromTwitch(EmoteTwitch emote, EmoteType type) => Emote(
@@ -279,6 +281,7 @@ class Emote {
         zeroWidth: false,
         url: 'https://static-cdn.jtvnw.net/emoticons/v2/${emote.id}/default/dark/3.0',
         type: type,
+        ownerId: emote.ownerId,
       );
 
   factory Emote.fromBTTV(EmoteBTTV emote, EmoteType type) => Emote(

--- a/lib/models/emotes.g.dart
+++ b/lib/models/emotes.g.dart
@@ -131,6 +131,7 @@ Emote _$EmoteFromJson(Map<String, dynamic> json) => Emote(
       zeroWidth: json['zeroWidth'] as bool,
       url: json['url'] as String,
       type: $enumDecode(_$EmoteTypeEnumMap, json['type']),
+      ownerId: json['ownerId'] as String?,
     );
 
 Map<String, dynamic> _$EmoteToJson(Emote instance) => <String, dynamic>{
@@ -140,6 +141,7 @@ Map<String, dynamic> _$EmoteToJson(Emote instance) => <String, dynamic>{
       'zeroWidth': instance.zeroWidth,
       'url': instance.url,
       'type': _$EmoteTypeEnumMap[instance.type],
+      'ownerId': instance.ownerId,
     };
 
 const _$EmoteTypeEnumMap = {

--- a/lib/screens/channel/chat/emote_menu/emote_menu.dart
+++ b/lib/screens/channel/chat/emote_menu/emote_menu.dart
@@ -81,7 +81,7 @@ class _EmoteMenuState extends State<EmoteMenu> {
               Observer(
                 builder: (_) => EmoteMenuPanel(
                   chatStore: widget.chatStore,
-                  emotes: widget.chatStore.assetsStore.userEmoteToObject.values.toList(),
+                  twitchEmotes: widget.chatStore.assetsStore.userEmoteSectionToEmotes,
                 ),
               ),
               Observer(

--- a/lib/screens/channel/chat/emote_menu/emote_menu_panel.dart
+++ b/lib/screens/channel/chat/emote_menu/emote_menu_panel.dart
@@ -6,78 +6,72 @@ import 'package:frosty/widgets/section_header.dart';
 
 class EmoteMenuPanel extends StatelessWidget {
   final ChatStore chatStore;
-  final List<Emote> emotes;
+  final List<Emote>? emotes;
+  final Map<String, List<Emote>>? twitchEmotes;
 
   const EmoteMenuPanel({
     Key? key,
     required this.chatStore,
-    required this.emotes,
+    this.emotes,
+    this.twitchEmotes,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final globalEmotes = emotes
-        .where((emote) =>
-            emote.type == EmoteType.twitchGlobal ||
-            emote.type == EmoteType.bttvGlobal ||
-            emote.type == EmoteType.ffzGlobal ||
-            emote.type == EmoteType.sevenTVGlobal)
-        .toList();
+    if (emotes != null) {
+      final globalEmotes =
+          emotes!.where((emote) => emote.type == EmoteType.bttvGlobal || emote.type == EmoteType.ffzGlobal || emote.type == EmoteType.sevenTVGlobal).toList();
 
-    final channelEmotes = emotes
-        .where((emote) =>
-            emote.type == EmoteType.twitchChannel ||
-            emote.type == EmoteType.bttvChannel ||
-            emote.type == EmoteType.bttvShared ||
-            emote.type == EmoteType.ffzChannel ||
-            emote.type == EmoteType.sevenTVChannel)
-        .toList();
+      final channelEmotes = emotes!
+          .where((emote) =>
+              emote.type == EmoteType.bttvChannel ||
+              emote.type == EmoteType.bttvShared ||
+              emote.type == EmoteType.ffzChannel ||
+              emote.type == EmoteType.sevenTVChannel)
+          .toList();
 
-    final subEmotes = emotes.where((emote) => emote.type == EmoteType.twitchSub).toList();
-    final miscEmotes = emotes.where((emote) => emote.type == EmoteType.twitchUnlocked).toList();
-
-    return CustomScrollView(
-      slivers: [
-        if (globalEmotes.isNotEmpty) ...[
-          const SliverToBoxAdapter(
-            child: SectionHeader(
-              'Global Emotes',
-              padding: EdgeInsets.symmetric(vertical: 5.0, horizontal: 10.0),
+      return CustomScrollView(
+        slivers: [
+          if (globalEmotes.isNotEmpty) ...[
+            const SliverToBoxAdapter(
+              child: SectionHeader(
+                'Global Emotes',
+                padding: EdgeInsets.symmetric(vertical: 5.0, horizontal: 10.0),
+              ),
             ),
-          ),
-          EmoteMenuSection(
-            chatStore: chatStore,
-            emotes: globalEmotes,
-          ),
+            EmoteMenuSection(
+              chatStore: chatStore,
+              emotes: globalEmotes,
+            ),
+          ],
+          if (channelEmotes.isNotEmpty) ...[
+            const SliverToBoxAdapter(
+              child: SectionHeader('Channel Emotes'),
+            ),
+            EmoteMenuSection(
+              chatStore: chatStore,
+              emotes: channelEmotes,
+            ),
+          ],
         ],
-        if (channelEmotes.isNotEmpty) ...[
-          const SliverToBoxAdapter(
-            child: SectionHeader('Channel Emotes'),
-          ),
-          EmoteMenuSection(
-            chatStore: chatStore,
-            emotes: channelEmotes,
-          ),
+      );
+    } else {
+      return CustomScrollView(
+        slivers: [
+          for (final entry in twitchEmotes!.entries) ...[
+            SliverToBoxAdapter(
+              child: SectionHeader(
+                entry.key,
+                padding: entry.key == 'Global Emotes' ? const EdgeInsets.symmetric(vertical: 5.0, horizontal: 10.0) : null,
+              ),
+            ),
+            EmoteMenuSection(
+              chatStore: chatStore,
+              emotes: entry.value,
+            ),
+          ]
         ],
-        if (subEmotes.isNotEmpty) ...[
-          const SliverToBoxAdapter(
-            child: SectionHeader('Subscribed Emotes'),
-          ),
-          EmoteMenuSection(
-            chatStore: chatStore,
-            emotes: subEmotes,
-          ),
-        ],
-        if (miscEmotes.isNotEmpty) ...[
-          const SliverToBoxAdapter(
-            child: SectionHeader('Unlocked Emotes'),
-          ),
-          EmoteMenuSection(
-            chatStore: chatStore,
-            emotes: miscEmotes,
-          ),
-        ],
-      ],
-    );
+      );
+    }
   }
 }

--- a/lib/screens/channel/stores/chat_assets_store.g.dart
+++ b/lib/screens/channel/stores/chat_assets_store.g.dart
@@ -85,6 +85,26 @@ mixin _$ChatAssetsStore on ChatAssetsStoreBase, Store {
     });
   }
 
+  late final _$_userEmoteSectionToEmotesAtom = Atom(
+      name: 'ChatAssetsStoreBase._userEmoteSectionToEmotes', context: context);
+
+  Map<String, List<Emote>> get userEmoteSectionToEmotes {
+    _$_userEmoteSectionToEmotesAtom.reportRead();
+    return super._userEmoteSectionToEmotes;
+  }
+
+  @override
+  Map<String, List<Emote>> get _userEmoteSectionToEmotes =>
+      userEmoteSectionToEmotes;
+
+  @override
+  set _userEmoteSectionToEmotes(Map<String, List<Emote>> value) {
+    _$_userEmoteSectionToEmotesAtom
+        .reportWrite(value, super._userEmoteSectionToEmotes, () {
+      super._userEmoteSectionToEmotes = value;
+    });
+  }
+
   late final _$_userToFFZBadgesAtom =
       Atom(name: 'ChatAssetsStoreBase._userToFFZBadges', context: context);
 
@@ -179,6 +199,18 @@ mixin _$ChatAssetsStore on ChatAssetsStoreBase, Store {
     return _$initAsyncAction.run(() => super.init());
   }
 
+  late final _$userEmotesFutureAsyncAction =
+      AsyncAction('ChatAssetsStoreBase.userEmotesFuture', context: context);
+
+  @override
+  Future<void> userEmotesFuture(
+      {required List<String> emoteSets,
+      required Map<String, String> headers,
+      required Function onError}) {
+    return _$userEmotesFutureAsyncAction.run(() => super.userEmotesFuture(
+        emoteSets: emoteSets, headers: headers, onError: onError));
+  }
+
   late final _$ChatAssetsStoreBaseActionController =
       ActionController(name: 'ChatAssetsStoreBase', context: context);
 
@@ -226,21 +258,6 @@ mixin _$ChatAssetsStore on ChatAssetsStoreBase, Store {
     try {
       return super.badgesFuture(
           channelId: channelId, headers: headers, onError: onError);
-    } finally {
-      _$ChatAssetsStoreBaseActionController.endAction(_$actionInfo);
-    }
-  }
-
-  @override
-  Future<void> userEmotesFuture(
-      {required List<String> emoteSets,
-      required Map<String, String> headers,
-      required Function onError}) {
-    final _$actionInfo = _$ChatAssetsStoreBaseActionController.startAction(
-        name: 'ChatAssetsStoreBase.userEmotesFuture');
-    try {
-      return super.userEmotesFuture(
-          emoteSets: emoteSets, headers: headers, onError: onError);
     } finally {
       _$ChatAssetsStoreBaseActionController.endAction(_$actionInfo);
     }

--- a/lib/widgets/section_header.dart
+++ b/lib/widgets/section_header.dart
@@ -2,14 +2,14 @@ import 'package:flutter/material.dart';
 
 class SectionHeader extends StatelessWidget {
   final String text;
-  final EdgeInsets padding;
+  final EdgeInsets? padding;
   final double? fontSize;
   final bool showDivider;
 
   const SectionHeader(
     this.text, {
     Key? key,
-    this.padding = const EdgeInsets.fromLTRB(10.0, 20.0, 10.0, 5.0),
+    this.padding,
     this.fontSize,
     this.showDivider = false,
   }) : super(key: key);
@@ -17,7 +17,7 @@ class SectionHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: padding,
+      padding: padding ?? const EdgeInsets.fromLTRB(10.0, 20.0, 10.0, 5.0),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [


### PR DESCRIPTION
Subscribed emotes are now grouped by channel name rather than lumped all together in one section.

Closes #142