### PR TITLE
Remove unused model fields

### DIFF
--- a/lib/models/badges.dart
+++ b/lib/models/badges.dart
@@ -2,7 +2,6 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'badges.g.dart';
 
-// Twitch Badges
 @JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
 class BadgeInfoTwitch {
   @JsonKey(name: 'image_url_1x')
@@ -12,19 +11,13 @@ class BadgeInfoTwitch {
   @JsonKey(name: 'image_url_4x')
   final String imageUrl4x;
 
-  final String description;
   final String title;
-  final String clickAction;
-  final String clickUrl;
 
   const BadgeInfoTwitch(
     this.imageUrl1x,
     this.imageUrl2x,
     this.imageUrl4x,
-    this.description,
     this.title,
-    this.clickAction,
-    this.clickUrl,
   );
 
   factory BadgeInfoTwitch.fromJson(Map<String, dynamic> json) => _$BadgeInfoTwitchFromJson(json);
@@ -33,22 +26,14 @@ class BadgeInfoTwitch {
 @JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
 class BadgeInfoFFZ {
   final int id;
-  final String name;
   final String title;
-  final int slot;
-  final String? replaces;
   final String color;
-  final String image;
   final BadgeUrlsFFZ urls;
 
   const BadgeInfoFFZ(
     this.id,
-    this.name,
     this.title,
-    this.slot,
-    this.replaces,
     this.color,
-    this.image,
     this.urls,
   );
 
@@ -75,15 +60,11 @@ class BadgeUrlsFFZ {
 
 @JsonSerializable(createToJson: false)
 class BadgeInfo7TV {
-  final String id;
-  final String name;
   final String tooltip;
   final List<List<String>> urls;
   final List<String> users;
 
   BadgeInfo7TV(
-    this.id,
-    this.name,
     this.tooltip,
     this.urls,
     this.users,
@@ -94,16 +75,10 @@ class BadgeInfo7TV {
 
 @JsonSerializable(createToJson: false)
 class BadgeInfoBTTV {
-  final String id;
-  final String name;
-  final String displayName;
   final String providerId;
   final BadgeDetailsBTTV badge;
 
   BadgeInfoBTTV(
-    this.id,
-    this.name,
-    this.displayName,
     this.providerId,
     this.badge,
   );

--- a/lib/models/badges.g.dart
+++ b/lib/models/badges.g.dart
@@ -11,20 +11,13 @@ BadgeInfoTwitch _$BadgeInfoTwitchFromJson(Map<String, dynamic> json) =>
       json['image_url_1x'] as String,
       json['image_url_2x'] as String,
       json['image_url_4x'] as String,
-      json['description'] as String,
       json['title'] as String,
-      json['click_action'] as String,
-      json['click_url'] as String,
     );
 
 BadgeInfoFFZ _$BadgeInfoFFZFromJson(Map<String, dynamic> json) => BadgeInfoFFZ(
       json['id'] as int,
-      json['name'] as String,
       json['title'] as String,
-      json['slot'] as int,
-      json['replaces'] as String?,
       json['color'] as String,
-      json['image'] as String,
       BadgeUrlsFFZ.fromJson(json['urls'] as Map<String, dynamic>),
     );
 
@@ -35,8 +28,6 @@ BadgeUrlsFFZ _$BadgeUrlsFFZFromJson(Map<String, dynamic> json) => BadgeUrlsFFZ(
     );
 
 BadgeInfo7TV _$BadgeInfo7TVFromJson(Map<String, dynamic> json) => BadgeInfo7TV(
-      json['id'] as String,
-      json['name'] as String,
       json['tooltip'] as String,
       (json['urls'] as List<dynamic>)
           .map((e) => (e as List<dynamic>).map((e) => e as String).toList())
@@ -46,9 +37,6 @@ BadgeInfo7TV _$BadgeInfo7TVFromJson(Map<String, dynamic> json) => BadgeInfo7TV(
 
 BadgeInfoBTTV _$BadgeInfoBTTVFromJson(Map<String, dynamic> json) =>
     BadgeInfoBTTV(
-      json['id'] as String,
-      json['name'] as String,
-      json['displayName'] as String,
       json['providerId'] as String,
       BadgeDetailsBTTV.fromJson(json['badge'] as Map<String, dynamic>),
     );

--- a/lib/models/channel.dart
+++ b/lib/models/channel.dart
@@ -8,21 +8,11 @@ class Channel {
   final String broadcasterId;
   final String broadcasterLogin;
   final String broadcasterName;
-  final String broadcasterLanguage;
-  final String gameId;
-  final String gameName;
-  final String title;
-  final int delay;
 
   const Channel({
     required this.broadcasterId,
     required this.broadcasterLogin,
     required this.broadcasterName,
-    required this.broadcasterLanguage,
-    required this.gameId,
-    required this.gameName,
-    required this.title,
-    required this.delay,
   });
 
   factory Channel.fromJson(Map<String, dynamic> json) => _$ChannelFromJson(json);
@@ -31,29 +21,17 @@ class Channel {
 // Object for Twitch channel search query.
 @JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
 class ChannelQuery {
-  final String broadcasterLanguage;
   final String broadcasterLogin;
   final String displayName;
-  final String gameId;
-  final String gameName;
   final String id;
   final bool isLive;
-  final List<String> tagIds;
-  final String thumbnailUrl;
-  final String title;
   final String startedAt;
 
   const ChannelQuery({
-    required this.broadcasterLanguage,
     required this.broadcasterLogin,
     required this.displayName,
-    required this.gameId,
-    required this.gameName,
     required this.id,
     required this.isLive,
-    required this.tagIds,
-    required this.thumbnailUrl,
-    required this.title,
     required this.startedAt,
   });
 

--- a/lib/models/channel.g.dart
+++ b/lib/models/channel.g.dart
@@ -10,24 +10,12 @@ Channel _$ChannelFromJson(Map<String, dynamic> json) => Channel(
       broadcasterId: json['broadcaster_id'] as String,
       broadcasterLogin: json['broadcaster_login'] as String,
       broadcasterName: json['broadcaster_name'] as String,
-      broadcasterLanguage: json['broadcaster_language'] as String,
-      gameId: json['game_id'] as String,
-      gameName: json['game_name'] as String,
-      title: json['title'] as String,
-      delay: json['delay'] as int,
     );
 
 ChannelQuery _$ChannelQueryFromJson(Map<String, dynamic> json) => ChannelQuery(
-      broadcasterLanguage: json['broadcaster_language'] as String,
       broadcasterLogin: json['broadcaster_login'] as String,
       displayName: json['display_name'] as String,
-      gameId: json['game_id'] as String,
-      gameName: json['game_name'] as String,
       id: json['id'] as String,
       isLive: json['is_live'] as bool,
-      tagIds:
-          (json['tag_ids'] as List<dynamic>).map((e) => e as String).toList(),
-      thumbnailUrl: json['thumbnail_url'] as String,
-      title: json['title'] as String,
       startedAt: json['started_at'] as String,
     );

--- a/lib/models/emotes.dart
+++ b/lib/models/emotes.dart
@@ -4,48 +4,18 @@ import 'package:json_annotation/json_annotation.dart';
 part 'emotes.g.dart';
 
 // * Twitch Emotes *
-@JsonSerializable(createToJson: false)
-class ImagesTwitch {
-  @JsonKey(name: 'url_1x')
-  final String url1x;
-  @JsonKey(name: 'url_2x')
-  final String url2x;
-  @JsonKey(name: 'url_4x')
-  final String url4x;
-
-  const ImagesTwitch(
-    this.url1x,
-    this.url2x,
-    this.url4x,
-  );
-
-  factory ImagesTwitch.fromJson(Map<String, dynamic> json) => _$ImagesTwitchFromJson(json);
-}
-
 @JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
 class EmoteTwitch {
   final String id;
   final String name;
-  final ImagesTwitch images;
-  final String? tier;
   final String? emoteType;
-  final String? emoteSetId;
   final String? ownerId;
-  final List<String> format;
-  final List<String> scale;
-  final List<String> themeMode;
 
   const EmoteTwitch(
     this.id,
     this.name,
-    this.images,
-    this.tier,
     this.emoteType,
-    this.emoteSetId,
     this.ownerId,
-    this.format,
-    this.scale,
-    this.themeMode,
   );
 
   factory EmoteTwitch.fromJson(Map<String, dynamic> json) => _$EmoteTwitchFromJson(json);
@@ -56,48 +26,21 @@ class EmoteTwitch {
 class EmoteBTTV {
   final String id;
   final String code;
-  final String imageType;
-  final String? userId;
-  final UserBTTV? user;
 
   const EmoteBTTV(
     this.id,
     this.code,
-    this.imageType,
-    this.userId,
-    this.user,
   );
 
   factory EmoteBTTV.fromJson(Map<String, dynamic> json) => _$EmoteBTTVFromJson(json);
 }
 
 @JsonSerializable(createToJson: false)
-class UserBTTV {
-  final String id;
-  final String name;
-  final String displayName;
-  final String providerId;
-
-  const UserBTTV(
-    this.id,
-    this.name,
-    this.displayName,
-    this.providerId,
-  );
-
-  factory UserBTTV.fromJson(Map<String, dynamic> json) => _$UserBTTVFromJson(json);
-}
-
-@JsonSerializable(createToJson: false)
 class EmoteBTTVChannel {
-  final String id;
-  final List<String> bots;
   final List<EmoteBTTV> channelEmotes;
   final List<EmoteBTTV> sharedEmotes;
 
   const EmoteBTTVChannel(
-    this.id,
-    this.bots,
     this.channelEmotes,
     this.sharedEmotes,
   );
@@ -109,15 +52,11 @@ class EmoteBTTVChannel {
 @JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
 class RoomFFZ {
   final int set;
-  final String? moderatorBadge;
   final ImagesFFZ? vipBadge;
   final ImagesFFZ? modUrls;
-  // final Map<String, List<String>> userBadges;
-  // final Map<String, List<int>> userBadgesIds;
 
   const RoomFFZ(
     this.set,
-    this.moderatorBadge,
     this.vipBadge,
     this.modUrls,
   );
@@ -145,19 +84,15 @@ class ImagesFFZ {
 
 @JsonSerializable(createToJson: false)
 class EmoteFFZ {
-  final int id;
   final String name;
   final int height;
   final int width;
-  final OwnerFFZ owner;
   final ImagesFFZ urls;
 
   const EmoteFFZ(
-    this.id,
     this.name,
     this.height,
     this.width,
-    this.owner,
     this.urls,
   );
 
@@ -165,86 +100,16 @@ class EmoteFFZ {
 }
 
 @JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
-class OwnerFFZ {
-  @JsonKey(name: '_id')
-  final int id;
-  final String name;
-  final String displayName;
-
-  const OwnerFFZ(
-    this.id,
-    this.name,
-    this.displayName,
-  );
-
-  factory OwnerFFZ.fromJson(Map<String, dynamic> json) => _$OwnerFFZFromJson(json);
-}
-
-// * 7TV Emotes *
-@JsonSerializable(createToJson: false)
-class Role7TV {
-  final String id;
-  final String name;
-  final int position;
-  final int color;
-  final int allowed;
-  final int denied;
-  @JsonKey(name: 'default')
-  final bool? defaults;
-
-  const Role7TV(
-    this.id,
-    this.name,
-    this.position,
-    this.color,
-    this.allowed,
-    this.denied,
-    this.defaults,
-  );
-
-  factory Role7TV.fromJson(Map<String, dynamic> json) => _$Role7TVFromJson(json);
-}
-
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
-class Owner7TV {
-  final String id;
-  final String twitchId;
-  final String login;
-  final String displayName;
-  final Role7TV role;
-
-  const Owner7TV(
-    this.id,
-    this.twitchId,
-    this.login,
-    this.displayName,
-    this.role,
-  );
-
-  factory Owner7TV.fromJson(Map<String, dynamic> json) => _$Owner7TVFromJson(json);
-}
-
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
 class Emote7TV {
-  final String id;
   final String name;
-  final Owner7TV? owner;
-  final int visibility;
   final List<String> visibilitySimple;
-  final String mime;
-  final int status;
   final List<int> width;
   final List<int> height;
   final List<List<String>> urls;
 
   const Emote7TV(
-    this.id,
     this.name,
-    this.owner,
-    this.visibility,
     this.visibilitySimple,
-    this.mime,
-    this.status,
     this.width,
     this.height,
     this.urls,

--- a/lib/models/emotes.g.dart
+++ b/lib/models/emotes.g.dart
@@ -6,46 +6,20 @@ part of 'emotes.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-ImagesTwitch _$ImagesTwitchFromJson(Map<String, dynamic> json) => ImagesTwitch(
-      json['url_1x'] as String,
-      json['url_2x'] as String,
-      json['url_4x'] as String,
-    );
-
 EmoteTwitch _$EmoteTwitchFromJson(Map<String, dynamic> json) => EmoteTwitch(
       json['id'] as String,
       json['name'] as String,
-      ImagesTwitch.fromJson(json['images'] as Map<String, dynamic>),
-      json['tier'] as String?,
       json['emote_type'] as String?,
-      json['emote_set_id'] as String?,
       json['owner_id'] as String?,
-      (json['format'] as List<dynamic>).map((e) => e as String).toList(),
-      (json['scale'] as List<dynamic>).map((e) => e as String).toList(),
-      (json['theme_mode'] as List<dynamic>).map((e) => e as String).toList(),
     );
 
 EmoteBTTV _$EmoteBTTVFromJson(Map<String, dynamic> json) => EmoteBTTV(
       json['id'] as String,
       json['code'] as String,
-      json['imageType'] as String,
-      json['userId'] as String?,
-      json['user'] == null
-          ? null
-          : UserBTTV.fromJson(json['user'] as Map<String, dynamic>),
-    );
-
-UserBTTV _$UserBTTVFromJson(Map<String, dynamic> json) => UserBTTV(
-      json['id'] as String,
-      json['name'] as String,
-      json['displayName'] as String,
-      json['providerId'] as String,
     );
 
 EmoteBTTVChannel _$EmoteBTTVChannelFromJson(Map<String, dynamic> json) =>
     EmoteBTTVChannel(
-      json['id'] as String,
-      (json['bots'] as List<dynamic>).map((e) => e as String).toList(),
       (json['channelEmotes'] as List<dynamic>)
           .map((e) => EmoteBTTV.fromJson(e as Map<String, dynamic>))
           .toList(),
@@ -56,7 +30,6 @@ EmoteBTTVChannel _$EmoteBTTVChannelFromJson(Map<String, dynamic> json) =>
 
 RoomFFZ _$RoomFFZFromJson(Map<String, dynamic> json) => RoomFFZ(
       json['set'] as int,
-      json['moderator_badge'] as String?,
       json['vip_badge'] == null
           ? null
           : ImagesFFZ.fromJson(json['vip_badge'] as Map<String, dynamic>),
@@ -72,50 +45,17 @@ ImagesFFZ _$ImagesFFZFromJson(Map<String, dynamic> json) => ImagesFFZ(
     );
 
 EmoteFFZ _$EmoteFFZFromJson(Map<String, dynamic> json) => EmoteFFZ(
-      json['id'] as int,
       json['name'] as String,
       json['height'] as int,
       json['width'] as int,
-      OwnerFFZ.fromJson(json['owner'] as Map<String, dynamic>),
       ImagesFFZ.fromJson(json['urls'] as Map<String, dynamic>),
     );
 
-OwnerFFZ _$OwnerFFZFromJson(Map<String, dynamic> json) => OwnerFFZ(
-      json['_id'] as int,
-      json['name'] as String,
-      json['display_name'] as String,
-    );
-
-Role7TV _$Role7TVFromJson(Map<String, dynamic> json) => Role7TV(
-      json['id'] as String,
-      json['name'] as String,
-      json['position'] as int,
-      json['color'] as int,
-      json['allowed'] as int,
-      json['denied'] as int,
-      json['default'] as bool?,
-    );
-
-Owner7TV _$Owner7TVFromJson(Map<String, dynamic> json) => Owner7TV(
-      json['id'] as String,
-      json['twitch_id'] as String,
-      json['login'] as String,
-      json['display_name'] as String,
-      Role7TV.fromJson(json['role'] as Map<String, dynamic>),
-    );
-
 Emote7TV _$Emote7TVFromJson(Map<String, dynamic> json) => Emote7TV(
-      json['id'] as String,
       json['name'] as String,
-      json['owner'] == null
-          ? null
-          : Owner7TV.fromJson(json['owner'] as Map<String, dynamic>),
-      json['visibility'] as int,
       (json['visibility_simple'] as List<dynamic>)
           .map((e) => e as String)
           .toList(),
-      json['mime'] as String,
-      json['status'] as int,
       (json['width'] as List<dynamic>).map((e) => e as int).toList(),
       (json['height'] as List<dynamic>).map((e) => e as int).toList(),
       (json['urls'] as List<dynamic>)

--- a/lib/models/stream.dart
+++ b/lib/models/stream.dart
@@ -5,36 +5,26 @@ part 'stream.g.dart';
 // Object for live Twitch streams.
 @JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
 class StreamTwitch {
-  final String id;
   final String userId;
   final String userLogin;
   final String userName;
   final String gameId;
   final String gameName;
-  final String type;
   final String title;
   final int viewerCount;
   final String startedAt;
-  final String language;
   final String thumbnailUrl;
-  final List<String>? tagIds;
-  final bool isMature;
 
   const StreamTwitch(
-    this.id,
     this.userId,
     this.userLogin,
     this.userName,
     this.gameId,
     this.gameName,
-    this.type,
     this.title,
     this.viewerCount,
     this.startedAt,
-    this.language,
     this.thumbnailUrl,
-    this.tagIds,
-    this.isMature,
   );
 
   factory StreamTwitch.fromJson(Map<String, dynamic> json) => _$StreamTwitchFromJson(json);

--- a/lib/models/stream.g.dart
+++ b/lib/models/stream.g.dart
@@ -7,20 +7,15 @@ part of 'stream.dart';
 // **************************************************************************
 
 StreamTwitch _$StreamTwitchFromJson(Map<String, dynamic> json) => StreamTwitch(
-      json['id'] as String,
       json['user_id'] as String,
       json['user_login'] as String,
       json['user_name'] as String,
       json['game_id'] as String,
       json['game_name'] as String,
-      json['type'] as String,
       json['title'] as String,
       json['viewer_count'] as int,
       json['started_at'] as String,
-      json['language'] as String,
       json['thumbnail_url'] as String,
-      (json['tag_ids'] as List<dynamic>?)?.map((e) => e as String).toList(),
-      json['is_mature'] as bool,
     );
 
 StreamsTwitch _$StreamsTwitchFromJson(Map<String, dynamic> json) =>

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -8,25 +8,13 @@ class UserTwitch {
   final String id;
   final String login;
   final String displayName;
-  final String type;
-  final String broadcasterType;
-  final String description;
   final String profileImageUrl;
-  final String offlineImageUrl;
-  final int viewCount;
-  final String createdAt;
 
   const UserTwitch(
     this.id,
     this.login,
     this.displayName,
-    this.type,
-    this.broadcasterType,
-    this.description,
     this.profileImageUrl,
-    this.offlineImageUrl,
-    this.viewCount,
-    this.createdAt,
   );
 
   factory UserTwitch.fromJson(Map<String, dynamic> json) => _$UserTwitchFromJson(json);

--- a/lib/models/user.g.dart
+++ b/lib/models/user.g.dart
@@ -10,13 +10,7 @@ UserTwitch _$UserTwitchFromJson(Map<String, dynamic> json) => UserTwitch(
       json['id'] as String,
       json['login'] as String,
       json['display_name'] as String,
-      json['type'] as String,
-      json['broadcaster_type'] as String,
-      json['description'] as String,
       json['profile_image_url'] as String,
-      json['offline_image_url'] as String,
-      json['view_count'] as int,
-      json['created_at'] as String,
     );
 
 UserBlockedTwitch _$UserBlockedTwitchFromJson(Map<String, dynamic> json) =>

--- a/test/emote_test.dart
+++ b/test/emote_test.dart
@@ -38,15 +38,7 @@ void main() {
 
       expect(emote.id, '304456832');
       expect(emote.name, 'twitchdevPitchfork');
-      expect(emote.images.url1x, 'https://static-cdn.jtvnw.net/emoticons/v2/304456832/static/light/1.0');
-      expect(emote.images.url2x, 'https://static-cdn.jtvnw.net/emoticons/v2/304456832/static/light/2.0');
-      expect(emote.images.url4x, 'https://static-cdn.jtvnw.net/emoticons/v2/304456832/static/light/3.0');
-      expect(emote.tier, '1000');
       expect(emote.emoteType, 'subscriptions');
-      expect(emote.emoteSetId, '301590448');
-      expect(emote.format, ['static']);
-      expect(emote.scale, ['1.0', '2.0', '3.0']);
-      expect(emote.themeMode, ['light', 'dark']);
     });
   });
 
@@ -66,8 +58,6 @@ void main() {
 
       expect(emote.id, '54fa8f1401e468494b85b537');
       expect(emote.code, ':tf:');
-      expect(emote.imageType, 'png');
-      expect(emote.userId, '5561169bd6b9d206222a8c19');
     });
 
     test('shared emote should parse correctly', () {
@@ -90,11 +80,6 @@ void main() {
 
       expect(emote.id, '5590b223b344e2c42a9e28e3');
       expect(emote.code, 'EZ');
-      expect(emote.imageType, 'png');
-      expect(emote.user?.id, '558f7862b344e2c42a9e2822');
-      expect(emote.user?.name, 'helloboat');
-      expect(emote.user?.displayName, 'helloboat');
-      expect(emote.user?.providerId, '39819556');
     });
 
     test('global emotes should parse correctly', () {
@@ -113,13 +98,10 @@ void main() {
 
       final emoteIds = ['54fa903b01e468494b85b53f', '54fa909b01e468494b85b542', '54fa90ba01e468494b85b543', '54fa90f201e468494b85b545'];
       final emoteCodes = ['DatSauce', 'ForeverAlone', 'GabeN', 'HailHelix'];
-      final userIds = ['5561169bd6b9d206222a8c19', '5561169bd6b9d206222a8c19', '5561169bd6b9d206222a8c19', '5561169bd6b9d206222a8c19'];
 
       emotes.asMap().forEach((index, emote) {
         expect(emote.id, emoteIds[index]);
         expect(emote.code, emoteCodes[index]);
-        expect(emote.imageType, 'png');
-        expect(emote.userId, userIds[index]);
       });
     });
 
@@ -155,27 +137,16 @@ void main() {
       ''';
 
       final decoded = jsonDecode(sampleJson);
-      final result = EmoteBTTVChannel.fromJson(decoded);
 
-      expect(result.id, '5509bd19a607044d1a3dd1bb');
-      expect(result.bots, ['emotestats', 'hnlbot']);
-
-      final channelEmote = result.channelEmotes.first;
+      final channelEmote = EmoteBTTV.fromJson(decoded['channelEmotes'].first);
 
       expect(channelEmote.id, '5509bd3ba607044d1a3dd1bc');
       expect(channelEmote.code, 'sodaTP');
-      expect(channelEmote.imageType, 'png');
-      expect(channelEmote.userId, '5509bd19a607044d1a3dd1bb');
 
-      final sharedEmote = result.sharedEmotes.first;
+      final sharedEmote = EmoteBTTV.fromJson(decoded['sharedEmotes'].first);
 
       expect(sharedEmote.id, '5ed3bde8f54be95e2a838279');
       expect(sharedEmote.code, 'pugPls');
-      expect(sharedEmote.imageType, 'gif');
-      expect(sharedEmote.user?.id, '5c5510a1c0a5642a696190d9');
-      expect(sharedEmote.user?.name, 'wolfabelle');
-      expect(sharedEmote.user?.displayName, 'Wolfabelle');
-      expect(sharedEmote.user?.providerId, '190146087');
     });
   });
 
@@ -213,13 +184,9 @@ void main() {
       final json = jsonDecode(sampleJson);
       final emote = EmoteFFZ.fromJson(json);
 
-      expect(emote.id, 27081);
       expect(emote.height, 30);
       expect(emote.width, 40);
       expect(emote.name, 'ZreknarF');
-      expect(emote.owner.id, 1);
-      expect(emote.owner.name, 'sirstendec');
-      expect(emote.owner.displayName, 'SirStendec');
       expect(emote.urls.url1x, '//cdn.frankerfacez.com/emote/27081/1');
       expect(emote.urls.url2x, '//cdn.frankerfacez.com/emote/27081/2');
       expect(emote.urls.url4x, '//cdn.frankerfacez.com/emote/27081/4');
@@ -278,13 +245,8 @@ void main() {
       final json = jsonDecode(sampleGlobal7TVEmote);
       final emote = Emote7TV.fromJson(json);
 
-      expect(emote.id, '603ca884faf3a00014dff0ab');
       expect(emote.name, 'gachiBASS');
-      expect(emote.owner, null);
-      expect(emote.visibility, 2);
       expect(emote.visibilitySimple, ['GLOBAL']);
-      expect(emote.mime, 'image/gif');
-      expect(emote.status, 3);
       expect(emote.width, [32, 48, 76, 128]);
       expect(emote.height, [32, 48, 76, 128]);
 
@@ -363,26 +325,9 @@ void main() {
       final json = jsonDecode(sampleEmote);
       final emote = Emote7TV.fromJson(json);
 
-      expect(emote.id, '603caea243b9e100141caf4f');
       expect(emote.name, 'TrollDespair');
 
-      expect(emote.owner, isNotNull);
-      expect(emote.owner?.id, '603cae2496832ffa78c758cd');
-      expect(emote.owner?.twitchId, '');
-      expect(emote.owner?.login, 'swyfty_');
-      expect(emote.owner?.displayName, 'swyfty_');
-      expect(emote.owner?.role.id, '000000000000000000000000');
-      expect(emote.owner?.role.name, '');
-      expect(emote.owner?.role.position, 0);
-      expect(emote.owner?.role.color, 0);
-      expect(emote.owner?.role.allowed, 523);
-      expect(emote.owner?.role.denied, 0);
-      expect(emote.owner?.role.defaults, true);
-
-      expect(emote.visibility, 0);
       expect(emote.visibilitySimple, []);
-      expect(emote.mime, 'image/png');
-      expect(emote.status, 3);
       expect(emote.width, [32, 48, 76, 128]);
       expect(emote.height, [32, 48, 76, 128]);
 

--- a/test/stream_test.dart
+++ b/test/stream_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:frosty/models/stream.dart';
 
@@ -30,19 +31,14 @@ void main() {
     final decoded = jsonDecode(sampleStream);
     final stream = StreamTwitch.fromJson(decoded);
 
-    expect(stream.id, '43809710301');
     expect(stream.userId, '71092938');
     expect(stream.userLogin, 'xqcow');
     expect(stream.userName, 'xQcOW');
     expect(stream.gameId, '508292');
     expect(stream.gameName, 'Bloons TD 6');
-    expect(stream.type, 'live');
     expect(stream.title, 'A shorter title...');
     expect(stream.viewerCount, 50051);
     expect(stream.startedAt, '2021-09-23T20:06:22Z');
-    expect(stream.language, 'en');
     expect(stream.thumbnailUrl, 'https://static-cdn.jtvnw.net/previews-ttv/live_user_xqcow-{width}x{height}.jpg');
-    expect(stream.tagIds, ['e6bb8b34-4c28-4b5f-94ed-12c1ebf2d0e4', '6ea6bca4-4712-4ab9-a906-e3336a9d8039', '6606e54c-f92d-40f6-8257-74977889ccdd']);
-    expect(stream.isMature, false);
   });
 }

--- a/test/user_test.dart
+++ b/test/user_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:frosty/models/user.dart';
 
@@ -25,12 +26,6 @@ void main() {
     expect(user.id, '88888888');
     expect(user.login, 'bob');
     expect(user.displayName, 'Bob');
-    expect(user.type, 'random type');
-    expect(user.broadcasterType, 'streamer');
-    expect(user.description, 'random description');
     expect(user.profileImageUrl, 'https://static-cdn.jtvnw.net/user-default-pictures-uv/ead5c8b2-a4c9-4724-b1dd-9f00b46cbd3d-profile_image-300x300.png');
-    expect(user.offlineImageUrl, '');
-    expect(user.viewCount, 94);
-    expect(user.createdAt, '2013-09-25T00:32:05Z');
   });
 }


### PR DESCRIPTION
Closes #165

Removes all fields from models that aren't used anywhere in the app. These unused fields cause unnecessary overhead and are prone to bugs in the event of future API changes.

Some of them will likely be re-added in the future in the event a new feature requires them.