### PR TITLE
Fix PiP not dismissing on iOS

### DIFF
--- a/lib/screens/channel/stores/video_store.dart
+++ b/lib/screens/channel/stores/video_store.dart
@@ -285,7 +285,10 @@ abstract class VideoStoreBase with Store {
 
   @action
   void dispose() {
-    controller?.runJavascript('document.getElementsByTagName("video")[0].pause();');
+    // Not ideal, but seems like the only way of disposing of the video properly.
+    // Will both prevent the video from continuing to play when dismissed and closes PiP on iOS.
+    controller?.reload();
+
     _disposeOverlayReaction();
     floating.dispose();
     sleepTimer?.cancel();


### PR DESCRIPTION
Fixes #166.

In order to properly dispose of the video/stream to prevent it from still playing and showing PiP, I made it so that the webview reloads (refreshes) when disposed of. This essentially removes the video from view and ensures that no video component exists for playback.

I initially tried loading a random URL, but the video still did not stop. Loading a random HTML string didn't work either.

 