### PR TITLE
Fix old data restoring on reinstall (Android)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
     <application
         android:label="Frosty"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:allowBackup="false">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/lib/core/auth/auth_store.dart
+++ b/lib/core/auth/auth_store.dart
@@ -7,6 +7,7 @@ import 'package:frosty/constants/constants.dart';
 import 'package:frosty/core/user/user_store.dart';
 import 'package:frosty/main.dart';
 import 'package:mobx/mobx.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 part 'auth_store.g.dart';
@@ -120,7 +121,13 @@ abstract class AuthBase with Store {
       }
 
       _error = null;
-    } catch (e) {
+    } catch (e, stackTrace) {
+      // If auth initialization failed, log the error to Sentry.
+      await Sentry.captureException(
+        e,
+        stackTrace: stackTrace,
+      );
+
       debugPrint(e.toString());
       _error = e.toString();
     }
@@ -145,8 +152,14 @@ abstract class AuthBase with Store {
 
       // Set the login status to logged in.
       if (user.details != null) _isLoggedIn = true;
-    } catch (error) {
-      debugPrint('Login failed due to $error');
+    } catch (e, stackTrace) {
+      // If login failed, log the error to Sentry.
+      await Sentry.captureException(
+        e,
+        stackTrace: stackTrace,
+      );
+
+      debugPrint('Login failed due to $e');
     }
   }
 
@@ -174,7 +187,13 @@ abstract class AuthBase with Store {
       _isLoggedIn = false;
 
       debugPrint('Successfully logged out');
-    } catch (e) {
+    } catch (e, stackTrace) {
+      // If logout failed, log the error to Sentry.
+      await Sentry.captureException(
+        e,
+        stackTrace: stackTrace,
+      );
+
       debugPrint(e.toString());
     }
   }


### PR DESCRIPTION
Also a potential fix for #169 (needs more investigation).

On Android, app data will always restore by default when reinstalling. This may cause conflicts and issues with old and new tokens, preferences, and values when reading and storing, especially when the backup is really old.

To fix this, I've disabled Auto Backup completely with `android:allowBackup="false"` in the Android app manifest.

I've also added some captures through Sentry in the auth methods so that I'll be able to identify auth issues when they arise (should have done this from the beginning).