### PR TITLE
Fix large blocked users list preventing login

### DIFF
--- a/lib/api/twitch_api.dart
+++ b/lib/api/twitch_api.dart
@@ -410,6 +410,12 @@ class TwitchApi {
         final result = blockedList.map((e) => UserBlockedTwitch.fromJson(e)).toList();
 
         if (cursor != null) {
+          // Wait a bit (150 milliseconds) before recursively calling.
+          // This will prevent going over the rate limit to due a massive blocked users list.
+          //
+          // With the Twitch API, we can make up to 800 requests per minute.
+          // Waiting 150 milliseconds between requests will cap the rate here at 400 requests per minute.
+          await Future.delayed(const Duration(milliseconds: 150));
           result.addAll(await getUserBlockedList(id: id, cursor: cursor, headers: headers));
         }
 

--- a/lib/core/user/user_store.dart
+++ b/lib/core/user/user_store.dart
@@ -27,7 +27,10 @@ abstract class UserStoreBase with Store {
     _details = await twitchApi.getUserInfo(headers: headers);
 
     // Get and update the current user's list of blocked users.
-    if (_details?.id != null) _blockedUsers = (await twitchApi.getUserBlockedList(id: _details!.id, headers: headers)).asObservable();
+    // Don't use await because having a huge list of blocked users will block the UI.
+    if (_details?.id != null) {
+      twitchApi.getUserBlockedList(id: _details!.id, headers: headers).then((blockedUsers) => _blockedUsers = blockedUsers.asObservable());
+    }
 
     _disposeReaction = autorun((_) => _blockedUsers.sort((a, b) => a.userLogin.compareTo(b.userLogin)));
   }


### PR DESCRIPTION
Fixes #169.

Thanks to the detailed reporting in #169, we were able to discover that having a really large list of blocked users was blocking the UI and preventing the login from completing properly.

### The cause
After logging in, there is an initialization process that involves fetching information regarding the logged-in user. These steps are performed sequentially through fetching with `await`, so the next steps must wait for the previous ones to complete.

When fetching blocked users, the logged-in user could have thousands, if not, hundreds of thousands of blocked users (one reason being bots). This will cause "jank" and essentially freeze the UI until all users have been fetched.

Furthermore, the Twitch API only allows fetching up to 100 blocked users per request, with a limit of 800 requests per minute. Therefore, when too many blocked users are fetched, it will prevent the login initialization from completing.

### The fix
In order to fix this, I've removed `await` from the request and have opted for a normal async future with a completion handler.  This will prevent the main thread from being blocked and perform the request in the "background".

To account for the 100 blocked users per request and the Twitch API limit, I've added a delay of 150 milliseconds between each request. This means that total requests for blocked users are capped at 400 per minute, half of the 800 per minute cap previously mentioned. Theoretically, this will prevent requests from throwing a rate limit error.