### PR TITLE
Fix infinite messages in chat when auto-scroll is off

### DIFF
--- a/lib/screens/channel/stores/chat_store.dart
+++ b/lib/screens/channel/stores/chat_store.dart
@@ -20,7 +20,7 @@ class ChatStore = ChatStoreBase with _$ChatStore;
 
 abstract class ChatStoreBase with Store {
   /// The total maximum amount of messages in chat.
-  static const _messageLimit = 10000;
+  static const _messageLimit = 5000;
 
   /// The maximum ammount of messages to render when autoscroll is enabled.
   static const _renderMessageLimit = 100;

--- a/lib/screens/channel/stores/chat_store.dart
+++ b/lib/screens/channel/stores/chat_store.dart
@@ -20,7 +20,7 @@ class ChatStore = ChatStoreBase with _$ChatStore;
 
 abstract class ChatStoreBase with Store {
   /// The total maximum amount of messages in chat.
-  static const _messageLimit = 5000;
+  static const _messageLimit = 10000;
 
   /// The maximum ammount of messages to render when autoscroll is enabled.
   static const _renderMessageLimit = 100;


### PR DESCRIPTION
When refactoring the chat in v2.1.0, I forgot to verify that the list of messages doesn't grow to infinity when auto-scroll is off. The "new" chat involves a buffer list for holding messages to be rendered later, so once auto-scroll is disabled, this buffer will grow infinitely.

To address this, I've made it so that once the message buffer reaches a certain limit, the buffer is moved to the visible list of chat messages, and then the buffer is cleared.