### PR TITLE
Fix wrong subcriber badges in chat

### DIFF
--- a/lib/screens/channel/stores/chat_assets_store.dart
+++ b/lib/screens/channel/stores/chat_assets_store.dart
@@ -159,8 +159,12 @@ abstract class ChatAssetsStoreBase with Store {
     required Function onError,
   }) =>
       Future.wait([
-        twitchApi.getBadgesGlobal().then((badges) => twitchBadgesToObject.addAll(badges)).catchError(onError),
-        twitchApi.getBadgesChannel(id: channelId).then((badges) => twitchBadgesToObject.addAll(badges)).catchError(onError),
+        // Get global badges first, then channel badges to avoid badge conflicts.
+        // We want the channel badges to override the global badges.
+        twitchApi
+            .getBadgesGlobal()
+            .then((badges) => twitchBadgesToObject.addAll(badges))
+            .then((_) => twitchApi.getBadgesChannel(id: channelId).then((badges) => twitchBadgesToObject.addAll(badges)).catchError(onError)),
         ffzApi.getBadges().then((badges) => _userToFFZBadges = badges).catchError(onError),
         sevenTVApi.getBadges().then((badges) => _userTo7TVBadges = badges).catchError(onError),
         bttvApi.getBadges().then((badges) => _userToBTTVBadges = badges).catchError(onError),


### PR DESCRIPTION
A while back, I made a change in the Future that fetches assets, resulting in a sort of race condition where the global badges override the channel badges with the same name. This resulted in default subscriber badges being shown rather than channel-specific subscriber badges.

To fix it, I've reverted the change so that the global badges are fetched first, THEN the channel badges.