### PR TITLE
Add the ability to reconnect to chat with notification

### DIFF
--- a/lib/screens/channel/chat/chat.dart
+++ b/lib/screens/channel/chat/chat.dart
@@ -73,18 +73,19 @@ class Chat extends StatelessWidget {
                                         color: Colors.white,
                                       ),
                                     ),
-                                    Button(
-                                      onPressed: () async {
-                                        // Paste clipboard text into the text controller.
-                                        final data = await Clipboard.getData(Clipboard.kTextPlain);
+                                    if (chatStore.notification!.contains('copied'))
+                                      Button(
+                                        onPressed: () async {
+                                          // Paste clipboard text into the text controller.
+                                          final data = await Clipboard.getData(Clipboard.kTextPlain);
 
-                                        if (data != null) chatStore.textController.text = data.text!;
+                                          if (data != null) chatStore.textController.text = data.text!;
 
-                                        chatStore.updateNotification('');
-                                      },
-                                      fill: false,
-                                      child: const Text('Paste'),
-                                    ),
+                                          chatStore.updateNotification('');
+                                        },
+                                        fill: false,
+                                        child: const Text('Paste'),
+                                      ),
                                   ],
                                 ),
                               ),

--- a/lib/screens/channel/chat/emote_menu/emote_menu.dart
+++ b/lib/screens/channel/chat/emote_menu/emote_menu.dart
@@ -4,7 +4,6 @@ import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:frosty/screens/channel/chat/emote_menu/emote_menu_panel.dart';
 import 'package:frosty/screens/channel/chat/emote_menu/recent_emotes_panel.dart';
 import 'package:frosty/screens/channel/stores/chat_store.dart';
-import 'package:frosty/widgets/alert_message.dart';
 import 'package:frosty/widgets/button.dart';
 
 class EmoteMenu extends StatefulWidget {
@@ -65,28 +64,6 @@ class _EmoteMenuState extends State<EmoteMenu> {
                         ),
                       ),
                     ),
-                  ),
-                ),
-              ),
-              Button(
-                onPressed: () async {
-                  await widget.chatStore.getAssets();
-
-                  if (!mounted) return;
-
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: AlertMessage(message: 'Emotes refreshed'),
-                      behavior: SnackBarBehavior.floating,
-                    ),
-                  );
-                },
-                color: Theme.of(context).colorScheme.secondary,
-                child: const Text(
-                  'REFRESH EMOTES',
-                  style: TextStyle(
-                    letterSpacing: 0.8,
-                    fontWeight: FontWeight.w600,
                   ),
                 ),
               ),

--- a/lib/screens/channel/video_chat.dart
+++ b/lib/screens/channel/video_chat.dart
@@ -103,15 +103,19 @@ class _VideoChatState extends State<VideoChat> {
               ListTile(
                 leading: const Icon(Icons.refresh),
                 title: const Text('Reconnect to chat'),
-                onTap: _chatStore.connectToChat,
+                onTap: () {
+                  _chatStore.updateNotification('Reconnecting to chat...');
+
+                  _chatStore.connectToChat();
+                },
               ),
               ListTile(
                 leading: const Icon(Icons.refresh),
-                title: const Text('Refresh emotes'),
+                title: const Text('Refresh badges and emotes'),
                 onTap: () async {
                   await _chatStore.getAssets();
 
-                  _chatStore.updateNotification('Emotes refreshed');
+                  _chatStore.updateNotification('Badges and emotes refreshed');
                 },
               ),
             ],

--- a/lib/screens/channel/video_chat.dart
+++ b/lib/screens/channel/video_chat.dart
@@ -77,6 +77,63 @@ class _VideoChatState extends State<VideoChat> {
   Widget build(BuildContext context) {
     final settingsStore = _chatStore.settings;
 
+    void showSettings() {
+      showModalBottomSheet(
+        backgroundColor: Colors.transparent,
+        context: context,
+        builder: (context) => FrostyModal(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                leading: const Icon(Icons.app_settings_alt),
+                title: const Text('App settings'),
+                onTap: () => showModalBottomSheet(
+                  backgroundColor: Colors.transparent,
+                  isScrollControlled: true,
+                  context: context,
+                  builder: (context) => FrostyModal(
+                    child: SizedBox(
+                      height: MediaQuery.of(context).size.height * 0.8,
+                      child: Settings(settingsStore: settingsStore),
+                    ),
+                  ),
+                ),
+              ),
+              ListTile(
+                leading: const Icon(Icons.refresh),
+                title: const Text('Reconnect to chat'),
+                onTap: _chatStore.connectToChat,
+              ),
+              ListTile(
+                leading: const Icon(Icons.refresh),
+                title: const Text('Refresh emotes'),
+                onTap: () async {
+                  await _chatStore.getAssets();
+
+                  _chatStore.updateNotification('Emotes refreshed');
+                },
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    final appBar = AppBar(
+      title: Text(
+        regexEnglish.hasMatch(_chatStore.displayName) ? _chatStore.displayName : '${_chatStore.displayName} (${_chatStore.channelName})',
+        style: const TextStyle(fontSize: 20),
+      ),
+      actions: [
+        IconButton(
+          tooltip: 'Settings',
+          icon: const Icon(Icons.settings),
+          onPressed: showSettings,
+        ),
+      ],
+    );
+
     final player = GestureDetector(
       onLongPress: _videoStore.handleToggleOverlay,
       child: _Video(
@@ -85,7 +142,10 @@ class _VideoChatState extends State<VideoChat> {
       ),
     );
 
-    final videoOverlay = _VideoOverlay(videoStore: _videoStore);
+    final videoOverlay = _VideoOverlay(
+      videoStore: _videoStore,
+      onSettingsPressed: showSettings,
+    );
 
     final overlay = GestureDetector(
       onLongPress: _videoStore.handleToggleOverlay,
@@ -136,30 +196,6 @@ class _VideoChatState extends State<VideoChat> {
     final chat = Chat(
       key: _chatKey,
       chatStore: _chatStore,
-    );
-
-    final appBar = AppBar(
-      title: Text(
-        regexEnglish.hasMatch(_chatStore.displayName) ? _chatStore.displayName : '${_chatStore.displayName} (${_chatStore.channelName})',
-        style: const TextStyle(fontSize: 20),
-      ),
-      actions: [
-        IconButton(
-          tooltip: 'Settings',
-          icon: const Icon(Icons.settings),
-          onPressed: () => showModalBottomSheet(
-            backgroundColor: Colors.transparent,
-            isScrollControlled: true,
-            context: context,
-            builder: (context) => FrostyModal(
-              child: SizedBox(
-                height: MediaQuery.of(context).size.height * 0.8,
-                child: Settings(settingsStore: settingsStore),
-              ),
-            ),
-          ),
-        ),
-      ],
     );
 
     final videoChat = Scaffold(
@@ -306,8 +342,13 @@ class _Video extends StatelessWidget {
 /// Creates a widget containing controls which enable interactions with an underlying [_Video] widget.
 class _VideoOverlay extends StatelessWidget {
   final VideoStore videoStore;
+  final void Function() onSettingsPressed;
 
-  const _VideoOverlay({Key? key, required this.videoStore}) : super(key: key);
+  const _VideoOverlay({
+    Key? key,
+    required this.videoStore,
+    required this.onSettingsPressed,
+  }) : super(key: key);
 
   Future<void> _showSleepTimerDialog(BuildContext context) {
     return showDialog(
@@ -401,17 +442,7 @@ class _VideoOverlay extends StatelessWidget {
         Icons.settings,
         color: Colors.white,
       ),
-      onPressed: () => showModalBottomSheet(
-        backgroundColor: Colors.transparent,
-        isScrollControlled: true,
-        context: context,
-        builder: (context) => FrostyModal(
-          child: SizedBox(
-            height: MediaQuery.of(context).size.height * 0.8,
-            child: Settings(settingsStore: videoStore.settingsStore),
-          ),
-        ),
-      ),
+      onPressed: onSettingsPressed,
     );
 
     final chatOverlayButton = Observer(


### PR DESCRIPTION
Adds a button that disconnects and reconnects the chat. This was needed because sometimes when the connection is unstable or the network is switched, the chat will just freeze, requiring the user to navigate and re-enter the channel in order to reconnect.

Now, there is a "Reconnect to chat" button that shows up in a new settings modal.

Also moves the refresh emotes/badges button from the emote menu to the new settings modal.

Also, notifications have been added for the reconnect and refresh emotes action.