### PR TITLE
Fix misaligned chat names when setting msg scale

### DIFF
--- a/lib/models/irc.dart
+++ b/lib/models/irc.dart
@@ -285,22 +285,15 @@ class IRCMessage {
       }
     }
 
-    // Printing template for debugging purposes.
-    // debugPrint('OLD - NAME: ${tags['display-name']!}, HUE: ${hsl.hue}, SATURATION: ${hsl.saturation}, LIGHNTESS: ${hsl.lightness}');
-    // debugPrint('NEW - NAME: ${tags['display-name']!}, HUE: ${hsl.hue}, SATURATION: ${hsl.saturation}, LIGHNTESS: ${hsl.lightness}');
-
+    // Add the display name (username) to the span and apply the onLongPressName callback.
     span.add(
-      WidgetSpan(
-        child: InkWell(
-          onLongPress: onLongPressName,
-          child: Text(
-            tags['display-name']!,
-            style: TextStyle(
-              color: color,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
+      TextSpan(
+        text: tags['display-name']!,
+        style: TextStyle(
+          color: color,
+          fontWeight: FontWeight.bold,
         ),
+        recognizer: LongPressGestureRecognizer()..onLongPress = onLongPressName,
       ),
     );
 


### PR DESCRIPTION
When setting the message scale setting above 1.0, display names in chat were misaligned. This was caused by  `alignment: PlaceholderAlignment.middle` missing from the `WidgetSpan`.

Although adding the alignment will technically fix it, using `WidgetSpan` results in display names being oversized. Furthermore, the `InkWell` widget used for making the name tappable causes the splash effect on the name to look weird.

As a fix, I've reverted the display name to use `TextSpan` and added a long tap gesture recognizer, essentially achieving the same behavior. Display names are now properly scaled and there won't be a weird splash effect when holding down the name.