### PR TITLE
Add first message highlights and various tweaks

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -82,7 +82,7 @@ void main() async {
 // Navigator key for sleep timer. Allows navigation popping without context.
 final navigatorKey = GlobalKey<NavigatorState>();
 
-const gray = Color.fromRGBO(22, 22, 22, 1.0);
+const gray = Color.fromRGBO(18, 18, 18, 1.0);
 const purple = Color(0xff9146ff);
 
 const inputTheme = InputDecorationTheme(

--- a/lib/screens/channel/channel.dart
+++ b/lib/screens/channel/channel.dart
@@ -17,10 +17,8 @@ import 'package:frosty/screens/channel/chat/stores/chat_store.dart';
 import 'package:frosty/screens/channel/video/video.dart';
 import 'package:frosty/screens/channel/video/video_overlay.dart';
 import 'package:frosty/screens/channel/video/video_store.dart';
-import 'package:frosty/screens/settings/settings.dart';
 import 'package:frosty/screens/settings/stores/auth_store.dart';
 import 'package:frosty/screens/settings/stores/settings_store.dart';
-import 'package:frosty/widgets/modal.dart';
 import 'package:provider/provider.dart';
 
 /// Creates a widget that shows the video stream (if live) and chat of the given user.
@@ -73,65 +71,11 @@ class _VideoChatState extends State<VideoChat> {
   Widget build(BuildContext context) {
     final settingsStore = _chatStore.settings;
 
-    void showSettings() {
-      showModalBottomSheet(
-        backgroundColor: Colors.transparent,
-        context: context,
-        builder: (context) => FrostyModal(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              ListTile(
-                leading: const Icon(Icons.app_settings_alt),
-                title: const Text('App settings'),
-                onTap: () => showModalBottomSheet(
-                  backgroundColor: Colors.transparent,
-                  isScrollControlled: true,
-                  context: context,
-                  builder: (context) => FrostyModal(
-                    child: SizedBox(
-                      height: MediaQuery.of(context).size.height * 0.8,
-                      child: Settings(settingsStore: settingsStore),
-                    ),
-                  ),
-                ),
-              ),
-              ListTile(
-                leading: const Icon(Icons.refresh),
-                title: const Text('Reconnect to chat'),
-                onTap: () {
-                  _chatStore.updateNotification('Reconnecting to chat...');
-
-                  _chatStore.connectToChat();
-                },
-              ),
-              ListTile(
-                leading: const Icon(Icons.refresh),
-                title: const Text('Refresh badges and emotes'),
-                onTap: () async {
-                  await _chatStore.getAssets();
-
-                  _chatStore.updateNotification('Badges and emotes refreshed');
-                },
-              ),
-            ],
-          ),
-        ),
-      );
-    }
-
     final appBar = AppBar(
       title: Text(
         regexEnglish.hasMatch(_chatStore.displayName) ? _chatStore.displayName : '${_chatStore.displayName} (${_chatStore.channelName})',
         style: const TextStyle(fontSize: 20),
       ),
-      actions: [
-        IconButton(
-          tooltip: 'Settings',
-          icon: const Icon(Icons.settings),
-          onPressed: showSettings,
-        ),
-      ],
     );
 
     final player = GestureDetector(
@@ -144,7 +88,6 @@ class _VideoChatState extends State<VideoChat> {
 
     final videoOverlay = VideoOverlay(
       videoStore: _videoStore,
-      onSettingsPressed: showSettings,
     );
 
     final overlay = GestureDetector(

--- a/lib/screens/channel/chat/chat.dart
+++ b/lib/screens/channel/chat/chat.dart
@@ -84,8 +84,8 @@ class Chat extends StatelessWidget {
                               : Button(
                                   padding: const EdgeInsets.symmetric(horizontal: 15.0, vertical: 10.0),
                                   onPressed: chatStore.resumeScroll,
-                                  icon: const Icon(Icons.arrow_circle_down),
-                                  child: const Text('Resume Scroll'),
+                                  icon: const Icon(Icons.arrow_downward),
+                                  child: const Text('Resume scroll'),
                                 ),
                         ),
                       ),

--- a/lib/screens/channel/chat/details/chat_details.dart
+++ b/lib/screens/channel/chat/details/chat_details.dart
@@ -33,16 +33,17 @@ class _ChatDetailsState extends State<ChatDetails> {
   Widget build(BuildContext context) {
     return FrostyModal(
       child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 20.0),
-            child: ChatModes(roomState: widget.chatDetailsStore.roomState),
+          ListTile(
+            title: ChatModes(roomState: widget.chatDetailsStore.roomState),
+          ),
+          const Divider(
+            height: 1.0,
+            thickness: 1.0,
           ),
           ListTile(
-            leading: const Icon(Icons.app_settings_alt),
-            title: const Text('App settings'),
+            leading: const Icon(Icons.settings),
+            title: const Text('Settings'),
             onTap: () => showModalBottomSheet(
               backgroundColor: Colors.transparent,
               isScrollControlled: true,

--- a/lib/screens/channel/chat/details/chat_details.dart
+++ b/lib/screens/channel/chat/details/chat_details.dart
@@ -4,6 +4,7 @@ import 'package:frosty/screens/channel/chat/details/chat_details_store.dart';
 import 'package:frosty/screens/channel/chat/details/chat_modes.dart';
 import 'package:frosty/screens/channel/chat/details/chat_users_list.dart';
 import 'package:frosty/screens/channel/chat/stores/chat_store.dart';
+import 'package:frosty/screens/settings/settings.dart';
 import 'package:frosty/widgets/modal.dart';
 
 class ChatDetails extends StatefulWidget {
@@ -32,28 +33,72 @@ class _ChatDetailsState extends State<ChatDetails> {
   @override
   Widget build(BuildContext context) {
     return FrostyModal(
-      child: SizedBox(
-        height: MediaQuery.of(context).size.height * 0.8,
-        child: GestureDetector(
-          onTap: FocusScope.of(context).unfocus,
-          child: Observer(
-            builder: (_) => Column(
-              children: [
-                Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 15.0),
-                  child: ChatModes(roomState: widget.chatDetailsStore.roomState),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 20.0),
+            child: ChatModes(roomState: widget.chatDetailsStore.roomState),
+          ),
+          ListTile(
+            leading: const Icon(Icons.app_settings_alt),
+            title: const Text('App settings'),
+            onTap: () => showModalBottomSheet(
+              backgroundColor: Colors.transparent,
+              isScrollControlled: true,
+              context: context,
+              builder: (context) => FrostyModal(
+                child: SizedBox(
+                  height: MediaQuery.of(context).size.height * 0.8,
+                  child: Settings(settingsStore: widget.chatStore.settings),
                 ),
-                Expanded(
-                  child: ChattersList(
-                    chatDetailsStore: widget.chatDetailsStore,
-                    chatStore: widget.chatStore,
-                    userLogin: widget.userLogin,
-                  ),
-                ),
-              ],
+              ),
             ),
           ),
-        ),
+          ListTile(
+            leading: const Icon(Icons.people),
+            title: const Text('Chatters'),
+            onTap: () => showModalBottomSheet(
+              backgroundColor: Colors.transparent,
+              isScrollControlled: true,
+              context: context,
+              builder: (context) => FrostyModal(
+                child: SizedBox(
+                  height: MediaQuery.of(context).size.height * 0.8,
+                  child: GestureDetector(
+                    onTap: FocusScope.of(context).unfocus,
+                    child: Observer(
+                      builder: (_) => ChattersList(
+                        chatDetailsStore: widget.chatDetailsStore,
+                        chatStore: widget.chatStore,
+                        userLogin: widget.userLogin,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          ListTile(
+            leading: const Icon(Icons.refresh),
+            title: const Text('Reconnect to chat'),
+            onTap: () {
+              widget.chatStore.updateNotification('Reconnecting to chat...');
+
+              widget.chatStore.connectToChat();
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.refresh),
+            title: const Text('Refresh badges and emotes'),
+            onTap: () async {
+              await widget.chatStore.getAssets();
+
+              widget.chatStore.updateNotification('Badges and emotes refreshed');
+            },
+          ),
+        ],
       ),
     );
   }

--- a/lib/screens/channel/chat/details/chat_details.dart
+++ b/lib/screens/channel/chat/details/chat_details.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:frosty/screens/channel/chat/details/chat_details_store.dart';
 import 'package:frosty/screens/channel/chat/details/chat_modes.dart';
 import 'package:frosty/screens/channel/chat/details/chat_users_list.dart';
@@ -68,12 +67,10 @@ class _ChatDetailsState extends State<ChatDetails> {
                   height: MediaQuery.of(context).size.height * 0.8,
                   child: GestureDetector(
                     onTap: FocusScope.of(context).unfocus,
-                    child: Observer(
-                      builder: (_) => ChattersList(
-                        chatDetailsStore: widget.chatDetailsStore,
-                        chatStore: widget.chatStore,
-                        userLogin: widget.userLogin,
-                      ),
+                    child: ChattersList(
+                      chatDetailsStore: widget.chatDetailsStore,
+                      chatStore: widget.chatStore,
+                      userLogin: widget.userLogin,
                     ),
                   ),
                 ),

--- a/lib/screens/channel/chat/details/chat_modes.dart
+++ b/lib/screens/channel/chat/details/chat_modes.dart
@@ -11,7 +11,7 @@ class ChatModes extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceAround,
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
         Tooltip(
           preferBelow: false,

--- a/lib/screens/channel/chat/widgets/chat_bottom_bar.dart
+++ b/lib/screens/channel/chat/widgets/chat_bottom_bar.dart
@@ -140,7 +140,7 @@ class ChatBottomBar extends StatelessWidget {
                   else
                     IconButton(
                       icon: Icon(Icons.adaptive.more),
-                      tooltip: 'Chat details',
+                      tooltip: 'More',
                       onPressed: () => showModalBottomSheet(
                         backgroundColor: Colors.transparent,
                         isScrollControlled: true,

--- a/lib/screens/channel/chat/widgets/chat_message.dart
+++ b/lib/screens/channel/chat/widgets/chat_message.dart
@@ -50,6 +50,8 @@ class ChatMessage extends StatelessWidget {
       chatStore.updateNotification('Message copied');
     }
 
+    final defaultTextStyle = DefaultTextStyle.of(context).style;
+
     return Observer(
       builder: (context) {
         Color? color;
@@ -59,13 +61,14 @@ class ChatMessage extends StatelessWidget {
           case Command.privateMessage:
           case Command.userState:
             // If user is being mentioned in the message, highlight it red.
-            if (ircMessage.mention == true) color = Colors.red.withOpacity(0.3);
+            if (ircMessage.mention == true) color = Colors.red.withOpacity(0.2);
+            if (ircMessage.tags['first-msg'] == '1') color = Colors.green.withOpacity(0.2);
 
             final messageSpan = Text.rich(
               TextSpan(
                 children: ircMessage.generateSpan(
                   onLongPressName: onLongPressName,
-                  style: DefaultTextStyle.of(context).style,
+                  style: defaultTextStyle,
                   assetsStore: chatStore.assetsStore,
                   emoteScale: chatStore.settings.emoteScale,
                   badgeScale: chatStore.settings.badgeScale,
@@ -82,32 +85,41 @@ class ChatMessage extends StatelessWidget {
             final replyUser = ircMessage.tags['reply-parent-display-name'];
             final replyBody = ircMessage.tags['reply-parent-msg-body'];
 
-            if (replyUser != null && replyBody != null) {
+            if ((replyUser != null && replyBody != null) || ircMessage.tags['first-msg'] == '1') {
               renderMessage = Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Opacity(
-                    opacity: 0.5,
-                    child: Row(
-                      children: [
-                        Icon(
-                          Icons.reply,
-                          size: defaultBadgeSize * chatStore.settings.badgeScale,
-                        ),
-                        const SizedBox(width: 5.0),
-                        Flexible(
-                          child: Tooltip(
-                            message: 'Replying to @$replyUser: $replyBody',
-                            preferBelow: false,
-                            child: Text(
-                              'Replying to @$replyUser: $replyBody',
-                              maxLines: 1,
-                              style: const TextStyle(overflow: TextOverflow.ellipsis),
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
+                  Row(
+                    children: [
+                      Icon(
+                        replyUser != null && replyBody != null ? Icons.reply : Icons.new_releases_outlined,
+                        size: defaultBadgeSize * chatStore.settings.badgeScale,
+                        color: defaultTextStyle.color?.withOpacity(0.5),
+                      ),
+                      const SizedBox(width: 5.0),
+                      Flexible(
+                        child: replyUser != null && replyBody != null
+                            ? Tooltip(
+                                message: 'Replying to @$replyUser: $replyBody',
+                                preferBelow: false,
+                                child: Text(
+                                  'Replying to @$replyUser: $replyBody',
+                                  maxLines: 1,
+                                  style: TextStyle(
+                                    overflow: TextOverflow.ellipsis,
+                                    color: defaultTextStyle.color?.withOpacity(0.5),
+                                  ),
+                                ),
+                              )
+                            : Text(
+                                'First time chatting',
+                                style: TextStyle(
+                                  fontWeight: FontWeight.w600,
+                                  color: defaultTextStyle.color?.withOpacity(0.5),
+                                ),
+                              ),
+                      ),
+                    ],
                   ),
                   const SizedBox(height: 5.0),
                   messageSpan,
@@ -124,15 +136,32 @@ class ChatMessage extends StatelessWidget {
             final banDuration = ircMessage.tags['ban-duration'];
 
             renderMessage = Opacity(
-              opacity: 0.5,
+              opacity: 0.4,
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
+                  if (banDuration == null)
+                    if (ircMessage.command == Command.clearMessage)
+                      const Text(
+                        'Message deleted',
+                        style: TextStyle(fontWeight: FontWeight.w600),
+                      )
+                    else
+                      const Text(
+                        'Permanently banned',
+                        style: TextStyle(fontWeight: FontWeight.w600),
+                      )
+                  else
+                    Text(
+                      'Timed out for $banDuration ${int.parse(banDuration) > 1 ? 'seconds' : 'second'}',
+                      style: const TextStyle(fontWeight: FontWeight.w600),
+                    ),
+                  const SizedBox(height: 5.0),
                   Text.rich(
                     TextSpan(
                       children: ircMessage.generateSpan(
                         onLongPressName: onLongPressName,
-                        style: DefaultTextStyle.of(context).style,
+                        style: defaultTextStyle,
                         assetsStore: chatStore.assetsStore,
                         emoteScale: chatStore.settings.emoteScale,
                         badgeScale: chatStore.settings.badgeScale,
@@ -145,23 +174,6 @@ class ChatMessage extends StatelessWidget {
                       ),
                     ),
                   ),
-                  const SizedBox(height: 5.0),
-                  if (banDuration == null)
-                    if (ircMessage.command == Command.clearMessage)
-                      const Text(
-                        'Message deleted',
-                        style: TextStyle(fontWeight: FontWeight.w600),
-                      )
-                    else
-                      const Text(
-                        'User permanently banned',
-                        style: TextStyle(fontWeight: FontWeight.w600),
-                      )
-                  else
-                    Text(
-                      'Timed out for $banDuration ${int.parse(banDuration) > 1 ? 'seconds' : 'second'}',
-                      style: const TextStyle(fontWeight: FontWeight.w600),
-                    )
                 ],
               ),
             );
@@ -173,7 +185,7 @@ class ChatMessage extends StatelessWidget {
             );
             break;
           case Command.userNotice:
-            color = Colors.deepPurple.withOpacity(0.3);
+            color = Colors.deepPurple.withOpacity(0.2);
 
             renderMessage = Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -181,14 +193,17 @@ class ChatMessage extends StatelessWidget {
                 if (ircMessage.tags.containsKey('system-msg'))
                   Text(
                     ircMessage.tags['system-msg']!,
-                    style: const TextStyle(fontWeight: FontWeight.w600),
+                    style: TextStyle(fontWeight: FontWeight.w600, color: defaultTextStyle.color?.withOpacity(0.5)),
                   ),
                 if (ircMessage.tags.containsKey('msg-id') && ircMessage.tags['msg-id'] == 'announcement')
                   Row(
-                    children: const [
-                      Icon(Icons.announcement),
-                      SizedBox(width: 5.0),
-                      Text(
+                    children: [
+                      Icon(
+                        Icons.announcement_outlined,
+                        size: defaultBadgeSize * chatStore.settings.badgeScale,
+                      ),
+                      const SizedBox(width: 5.0),
+                      const Text(
                         'Announcement',
                         style: TextStyle(fontWeight: FontWeight.w600),
                       ),
@@ -200,7 +215,7 @@ class ChatMessage extends StatelessWidget {
                     TextSpan(
                       children: ircMessage.generateSpan(
                         onLongPressName: onLongPressName,
-                        style: DefaultTextStyle.of(context).style,
+                        style: defaultTextStyle,
                         assetsStore: chatStore.assetsStore,
                         emoteScale: chatStore.settings.emoteScale,
                         badgeScale: chatStore.settings.badgeScale,

--- a/lib/screens/channel/chat/widgets/chat_message.dart
+++ b/lib/screens/channel/chat/widgets/chat_message.dart
@@ -181,7 +181,7 @@ class ChatMessage extends StatelessWidget {
           case Command.notice:
             renderMessage = Text.rich(
               TextSpan(text: ircMessage.message),
-              style: TextStyle(color: Theme.of(context).textTheme.bodyText2?.color?.withOpacity(0.5)),
+              style: TextStyle(color: defaultTextStyle.color?.withOpacity(0.5)),
             );
             break;
           case Command.userNotice:

--- a/lib/screens/channel/chat/widgets/chat_message.dart
+++ b/lib/screens/channel/chat/widgets/chat_message.dart
@@ -62,7 +62,7 @@ class ChatMessage extends StatelessWidget {
           case Command.userState:
             // If user is being mentioned in the message, highlight it red.
             if (ircMessage.mention == true) color = Colors.red.withOpacity(0.2);
-            if (ircMessage.tags['first-msg'] == '1') color = Colors.green.withOpacity(0.2);
+            if (chatStore.settings.highlightFirstTimeChatter && ircMessage.tags['first-msg'] == '1') color = Colors.green.withOpacity(0.2);
 
             final messageSpan = Text.rich(
               TextSpan(
@@ -85,7 +85,7 @@ class ChatMessage extends StatelessWidget {
             final replyUser = ircMessage.tags['reply-parent-display-name'];
             final replyBody = ircMessage.tags['reply-parent-msg-body'];
 
-            if ((replyUser != null && replyBody != null) || ircMessage.tags['first-msg'] == '1') {
+            if ((replyUser != null && replyBody != null) || (chatStore.settings.highlightFirstTimeChatter && ircMessage.tags['first-msg'] == '1')) {
               renderMessage = Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
@@ -185,50 +185,54 @@ class ChatMessage extends StatelessWidget {
             );
             break;
           case Command.userNotice:
-            color = Colors.deepPurple.withOpacity(0.2);
+            if (chatStore.settings.showUserNotices) {
+              color = Colors.deepPurple.withOpacity(0.2);
 
-            renderMessage = Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                if (ircMessage.tags.containsKey('system-msg'))
-                  Text(
-                    ircMessage.tags['system-msg']!,
-                    style: TextStyle(fontWeight: FontWeight.w600, color: defaultTextStyle.color?.withOpacity(0.5)),
-                  ),
-                if (ircMessage.tags.containsKey('msg-id') && ircMessage.tags['msg-id'] == 'announcement')
-                  Row(
-                    children: [
-                      Icon(
-                        Icons.announcement_outlined,
-                        size: defaultBadgeSize * chatStore.settings.badgeScale,
-                      ),
-                      const SizedBox(width: 5.0),
-                      const Text(
-                        'Announcement',
-                        style: TextStyle(fontWeight: FontWeight.w600),
-                      ),
-                    ],
-                  ),
-                const SizedBox(height: 5.0),
-                if (ircMessage.message != null)
-                  Text.rich(
-                    TextSpan(
-                      children: ircMessage.generateSpan(
-                        onLongPressName: onLongPressName,
-                        style: defaultTextStyle,
-                        assetsStore: chatStore.assetsStore,
-                        emoteScale: chatStore.settings.emoteScale,
-                        badgeScale: chatStore.settings.badgeScale,
-                        useZeroWidth: chatStore.settings.showZeroWidth,
-                        useReadableColors: chatStore.settings.useReadableColors,
-                        isLightTheme: Theme.of(context).brightness == Brightness.light,
-                        launchExternal: chatStore.settings.launchUrlExternal,
-                        timestamp: chatStore.settings.timestampType,
+              renderMessage = Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (ircMessage.tags.containsKey('system-msg'))
+                    Text(
+                      ircMessage.tags['system-msg']!,
+                      style: TextStyle(fontWeight: FontWeight.w600, color: defaultTextStyle.color?.withOpacity(0.5)),
+                    ),
+                  if (ircMessage.tags['msg-id'] == 'announcement')
+                    Row(
+                      children: [
+                        Icon(
+                          Icons.announcement_outlined,
+                          size: defaultBadgeSize * chatStore.settings.badgeScale,
+                        ),
+                        const SizedBox(width: 5.0),
+                        const Text(
+                          'Announcement',
+                          style: TextStyle(fontWeight: FontWeight.w600),
+                        ),
+                      ],
+                    ),
+                  const SizedBox(height: 5.0),
+                  if (ircMessage.message != null)
+                    Text.rich(
+                      TextSpan(
+                        children: ircMessage.generateSpan(
+                          onLongPressName: onLongPressName,
+                          style: defaultTextStyle,
+                          assetsStore: chatStore.assetsStore,
+                          emoteScale: chatStore.settings.emoteScale,
+                          badgeScale: chatStore.settings.badgeScale,
+                          useZeroWidth: chatStore.settings.showZeroWidth,
+                          useReadableColors: chatStore.settings.useReadableColors,
+                          isLightTheme: Theme.of(context).brightness == Brightness.light,
+                          launchExternal: chatStore.settings.launchUrlExternal,
+                          timestamp: chatStore.settings.timestampType,
+                        ),
                       ),
                     ),
-                  ),
-              ],
-            );
+                ],
+              );
+            } else {
+              renderMessage = const SizedBox();
+            }
             break;
           default:
             renderMessage = const SizedBox();

--- a/lib/screens/channel/video/video_overlay.dart
+++ b/lib/screens/channel/video/video_overlay.dart
@@ -14,12 +14,10 @@ import 'package:intl/intl.dart';
 /// Creates a widget containing controls which enable interactions with an underlying [Video] widget.
 class VideoOverlay extends StatelessWidget {
   final VideoStore videoStore;
-  final void Function() onSettingsPressed;
 
   const VideoOverlay({
     Key? key,
     required this.videoStore,
-    required this.onSettingsPressed,
   }) : super(key: key);
 
   Future<void> _showSleepTimerDialog(BuildContext context) {
@@ -108,15 +106,6 @@ class VideoOverlay extends StatelessWidget {
       ),
     );
 
-    final settingsButton = IconButton(
-      tooltip: 'Settings',
-      icon: const Icon(
-        Icons.settings,
-        color: Colors.white,
-      ),
-      onPressed: onSettingsPressed,
-    );
-
     final chatOverlayButton = Observer(
       builder: (_) => IconButton(
         tooltip: videoStore.settingsStore.fullScreenChatOverlay ? 'Hide chat overlay' : 'Show chat overlay',
@@ -196,7 +185,6 @@ class VideoOverlay extends StatelessWidget {
               backButton,
               const Spacer(),
               if (videoStore.settingsStore.fullScreen && orientation == Orientation.landscape) chatOverlayButton,
-              settingsButton,
             ],
           ),
           Align(
@@ -251,7 +239,6 @@ class VideoOverlay extends StatelessWidget {
                 const Spacer(),
                 if (videoStore.settingsStore.fullScreen && orientation == Orientation.landscape) chatOverlayButton,
                 sleepTimerButton,
-                settingsButton,
               ],
             ),
 

--- a/lib/screens/home/home.dart
+++ b/lib/screens/home/home.dart
@@ -82,7 +82,7 @@ class _HomeState extends State<Home> {
           title: Observer(
             builder: (_) {
               final titles = [
-                if (_authStore.isLoggedIn) 'Followed Streams',
+                if (_authStore.isLoggedIn) 'Following',
                 'Top',
                 'Search',
               ];
@@ -139,7 +139,7 @@ class _HomeState extends State<Home> {
               if (_authStore.isLoggedIn)
                 const BottomNavigationBarItem(
                   icon: Icon(Icons.favorite),
-                  label: 'Followed',
+                  label: 'Following',
                   tooltip: 'Followed streams',
                 ),
               const BottomNavigationBarItem(

--- a/lib/screens/home/stream_list/stream_card.dart
+++ b/lib/screens/home/stream_list/stream_card.dart
@@ -147,7 +147,6 @@ class StreamCard extends StatelessWidget {
               streamInfo.title.trim(),
               overflow: TextOverflow.ellipsis,
               style: TextStyle(
-                fontWeight: FontWeight.w500,
                 fontSize: subFontSize,
                 color: fontColor?.withOpacity(0.8),
               ),

--- a/lib/screens/home/stream_list/stream_card.dart
+++ b/lib/screens/home/stream_list/stream_card.dart
@@ -129,7 +129,7 @@ class StreamCard extends StatelessWidget {
                     streamerName,
                     style: TextStyle(
                       fontSize: large ? 20.0 : 16.0,
-                      fontWeight: FontWeight.bold,
+                      fontWeight: FontWeight.w600,
                       color: fontColor,
                     ),
                     overflow: TextOverflow.ellipsis,
@@ -149,7 +149,7 @@ class StreamCard extends StatelessWidget {
               style: TextStyle(
                 fontWeight: FontWeight.w500,
                 fontSize: subFontSize,
-                color: fontColor,
+                color: fontColor?.withOpacity(0.8),
               ),
             ),
           ),

--- a/lib/screens/home/top/categories/category_card.dart
+++ b/lib/screens/home/top/categories/category_card.dart
@@ -55,7 +55,7 @@ class CategoryCard extends StatelessWidget {
               padding: const EdgeInsets.all(10.0),
               child: Text(
                 category.name,
-                style: const TextStyle(fontWeight: FontWeight.bold),
+                style: const TextStyle(fontWeight: FontWeight.w600),
                 overflow: TextOverflow.ellipsis,
               ),
             ),

--- a/lib/screens/settings/chat_settings.dart
+++ b/lib/screens/settings/chat_settings.dart
@@ -218,6 +218,23 @@ class _ChatSettingsState extends State<ChatSettings> {
             ),
           ),
           const SectionHeader(
+            'Alerts',
+            padding: sectionPadding,
+            showDivider: true,
+          ),
+          SwitchListTile.adaptive(
+            title: const Text('Highlight first time chatters'),
+            value: settingsStore.highlightFirstTimeChatter,
+            onChanged: (newValue) => settingsStore.highlightFirstTimeChatter = newValue,
+          ),
+          SwitchListTile.adaptive(
+            isThreeLine: true,
+            title: const Text('Show notices'),
+            subtitle: const Text('Shows notices such as subs and re-subs, announcements, and raids.'),
+            value: settingsStore.showUserNotices,
+            onChanged: (newValue) => settingsStore.showUserNotices = newValue,
+          ),
+          const SectionHeader(
             'Message Sizing',
             padding: sectionPadding,
             showDivider: true,

--- a/lib/screens/settings/stores/settings_store.dart
+++ b/lib/screens/settings/stores/settings_store.dart
@@ -103,6 +103,10 @@ abstract class _SettingsStoreBase with Store {
   static const defaultShowChatMessageDividers = false;
   static const defaultTimestampType = TimestampType.disabled;
 
+  static const defaultHighlightFirstTimeChatter = true;
+  static const defaultShowUserNotices = true;
+  static const defaultShowAnnouncements = true;
+
   static const defaultBadgeScale = 1.0;
   static const defaultEmoteScale = 1.0;
   static const defaultMessageScale = 1.0;
@@ -165,6 +169,18 @@ abstract class _SettingsStoreBase with Store {
   @observable
   var timestampType = defaultTimestampType;
 
+  @JsonKey(defaultValue: defaultHighlightFirstTimeChatter)
+  @observable
+  var highlightFirstTimeChatter = defaultHighlightFirstTimeChatter;
+
+  @JsonKey(defaultValue: defaultShowUserNotices)
+  @observable
+  var showUserNotices = defaultHighlightFirstTimeChatter;
+
+  @JsonKey(defaultValue: defaultShowAnnouncements)
+  @observable
+  var showAnnouncements = defaultShowAnnouncements;
+
   @JsonKey(defaultValue: defaultBadgeScale)
   @observable
   var badgeScale = defaultBadgeScale;
@@ -201,6 +217,9 @@ abstract class _SettingsStoreBase with Store {
     showDeletedMessages = defaultShowDeletedMessages;
     showChatMessageDividers = defaultShowChatMessageDividers;
     timestampType = defaultTimestampType;
+    highlightFirstTimeChatter = defaultHighlightFirstTimeChatter;
+    showUserNotices = defaultShowUserNotices;
+    showAnnouncements = defaultShowAnnouncements;
     badgeScale = defaultBadgeScale;
     emoteScale = defaultEmoteScale;
     messageScale = defaultMessageScale;

--- a/lib/screens/settings/stores/settings_store.dart
+++ b/lib/screens/settings/stores/settings_store.dart
@@ -105,7 +105,6 @@ abstract class _SettingsStoreBase with Store {
 
   static const defaultHighlightFirstTimeChatter = true;
   static const defaultShowUserNotices = true;
-  static const defaultShowAnnouncements = true;
 
   static const defaultBadgeScale = 1.0;
   static const defaultEmoteScale = 1.0;
@@ -177,10 +176,6 @@ abstract class _SettingsStoreBase with Store {
   @observable
   var showUserNotices = defaultHighlightFirstTimeChatter;
 
-  @JsonKey(defaultValue: defaultShowAnnouncements)
-  @observable
-  var showAnnouncements = defaultShowAnnouncements;
-
   @JsonKey(defaultValue: defaultBadgeScale)
   @observable
   var badgeScale = defaultBadgeScale;
@@ -219,7 +214,6 @@ abstract class _SettingsStoreBase with Store {
     timestampType = defaultTimestampType;
     highlightFirstTimeChatter = defaultHighlightFirstTimeChatter;
     showUserNotices = defaultShowUserNotices;
-    showAnnouncements = defaultShowAnnouncements;
     badgeScale = defaultBadgeScale;
     emoteScale = defaultEmoteScale;
     messageScale = defaultMessageScale;

--- a/lib/screens/settings/stores/settings_store.g.dart
+++ b/lib/screens/settings/stores/settings_store.g.dart
@@ -45,7 +45,6 @@ SettingsStore _$SettingsStoreFromJson(Map<String, dynamic> json) =>
       ..highlightFirstTimeChatter =
           json['highlightFirstTimeChatter'] as bool? ?? true
       ..showUserNotices = json['showUserNotices'] as bool? ?? true
-      ..showAnnouncements = json['showAnnouncements'] as bool? ?? true
       ..badgeScale = (json['badgeScale'] as num?)?.toDouble() ?? 1.0
       ..emoteScale = (json['emoteScale'] as num?)?.toDouble() ?? 1.0
       ..messageScale = (json['messageScale'] as num?)?.toDouble() ?? 1.0
@@ -85,7 +84,6 @@ Map<String, dynamic> _$SettingsStoreToJson(SettingsStore instance) =>
       'timestampType': _$TimestampTypeEnumMap[instance.timestampType]!,
       'highlightFirstTimeChatter': instance.highlightFirstTimeChatter,
       'showUserNotices': instance.showUserNotices,
-      'showAnnouncements': instance.showAnnouncements,
       'badgeScale': instance.badgeScale,
       'emoteScale': instance.emoteScale,
       'messageScale': instance.messageScale,
@@ -547,22 +545,6 @@ mixin _$SettingsStore on _SettingsStoreBase, Store {
     });
   }
 
-  late final _$showAnnouncementsAtom =
-      Atom(name: '_SettingsStoreBase.showAnnouncements', context: context);
-
-  @override
-  bool get showAnnouncements {
-    _$showAnnouncementsAtom.reportRead();
-    return super.showAnnouncements;
-  }
-
-  @override
-  set showAnnouncements(bool value) {
-    _$showAnnouncementsAtom.reportWrite(value, super.showAnnouncements, () {
-      super.showAnnouncements = value;
-    });
-  }
-
   late final _$badgeScaleAtom =
       Atom(name: '_SettingsStoreBase.badgeScale', context: context);
 
@@ -806,7 +788,6 @@ showChatMessageDividers: ${showChatMessageDividers},
 timestampType: ${timestampType},
 highlightFirstTimeChatter: ${highlightFirstTimeChatter},
 showUserNotices: ${showUserNotices},
-showAnnouncements: ${showAnnouncements},
 badgeScale: ${badgeScale},
 emoteScale: ${emoteScale},
 messageScale: ${messageScale},

--- a/lib/screens/settings/stores/settings_store.g.dart
+++ b/lib/screens/settings/stores/settings_store.g.dart
@@ -42,6 +42,10 @@ SettingsStore _$SettingsStoreFromJson(Map<String, dynamic> json) =>
               _$TimestampTypeEnumMap, json['timestampType'],
               unknownValue: TimestampType.disabled) ??
           TimestampType.disabled
+      ..highlightFirstTimeChatter =
+          json['highlightFirstTimeChatter'] as bool? ?? true
+      ..showUserNotices = json['showUserNotices'] as bool? ?? true
+      ..showAnnouncements = json['showAnnouncements'] as bool? ?? true
       ..badgeScale = (json['badgeScale'] as num?)?.toDouble() ?? 1.0
       ..emoteScale = (json['emoteScale'] as num?)?.toDouble() ?? 1.0
       ..messageScale = (json['messageScale'] as num?)?.toDouble() ?? 1.0
@@ -79,6 +83,9 @@ Map<String, dynamic> _$SettingsStoreToJson(SettingsStore instance) =>
       'showDeletedMessages': instance.showDeletedMessages,
       'showChatMessageDividers': instance.showChatMessageDividers,
       'timestampType': _$TimestampTypeEnumMap[instance.timestampType]!,
+      'highlightFirstTimeChatter': instance.highlightFirstTimeChatter,
+      'showUserNotices': instance.showUserNotices,
+      'showAnnouncements': instance.showAnnouncements,
       'badgeScale': instance.badgeScale,
       'emoteScale': instance.emoteScale,
       'messageScale': instance.messageScale,
@@ -507,6 +514,55 @@ mixin _$SettingsStore on _SettingsStoreBase, Store {
     });
   }
 
+  late final _$highlightFirstTimeChatterAtom = Atom(
+      name: '_SettingsStoreBase.highlightFirstTimeChatter', context: context);
+
+  @override
+  bool get highlightFirstTimeChatter {
+    _$highlightFirstTimeChatterAtom.reportRead();
+    return super.highlightFirstTimeChatter;
+  }
+
+  @override
+  set highlightFirstTimeChatter(bool value) {
+    _$highlightFirstTimeChatterAtom
+        .reportWrite(value, super.highlightFirstTimeChatter, () {
+      super.highlightFirstTimeChatter = value;
+    });
+  }
+
+  late final _$showUserNoticesAtom =
+      Atom(name: '_SettingsStoreBase.showUserNotices', context: context);
+
+  @override
+  bool get showUserNotices {
+    _$showUserNoticesAtom.reportRead();
+    return super.showUserNotices;
+  }
+
+  @override
+  set showUserNotices(bool value) {
+    _$showUserNoticesAtom.reportWrite(value, super.showUserNotices, () {
+      super.showUserNotices = value;
+    });
+  }
+
+  late final _$showAnnouncementsAtom =
+      Atom(name: '_SettingsStoreBase.showAnnouncements', context: context);
+
+  @override
+  bool get showAnnouncements {
+    _$showAnnouncementsAtom.reportRead();
+    return super.showAnnouncements;
+  }
+
+  @override
+  set showAnnouncements(bool value) {
+    _$showAnnouncementsAtom.reportWrite(value, super.showAnnouncements, () {
+      super.showAnnouncements = value;
+    });
+  }
+
   late final _$badgeScaleAtom =
       Atom(name: '_SettingsStoreBase.badgeScale', context: context);
 
@@ -748,6 +804,9 @@ useReadableColors: ${useReadableColors},
 showDeletedMessages: ${showDeletedMessages},
 showChatMessageDividers: ${showChatMessageDividers},
 timestampType: ${timestampType},
+highlightFirstTimeChatter: ${highlightFirstTimeChatter},
+showUserNotices: ${showUserNotices},
+showAnnouncements: ${showAnnouncements},
 badgeScale: ${badgeScale},
 emoteScale: ${emoteScale},
 messageScale: ${messageScale},


### PR DESCRIPTION
This PR contains the following:
- **Added first message highlights**
- Added options to show/hide first message highlights and alerts
- Changed arrow for resume scroll button
- Reduced title opacity and font-weight on stream cards for consistency
- Renamed the "Followed Streams" tab to just "Following"
- **Moved the settings button from the video overlay to the bottom bar**
- Darkened the dark theme (again)