### PR TITLE
Add option to have emote menu button on left

### DIFF
--- a/lib/screens/channel/chat/widgets/chat_bottom_bar.dart
+++ b/lib/screens/channel/chat/widgets/chat_bottom_bar.dart
@@ -13,6 +13,16 @@ class ChatBottomBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final emoteMenuButton = IconButton(
+      color: chatStore.assetsStore.showEmoteMenu ? Theme.of(context).colorScheme.secondary : null,
+      tooltip: 'Emote menu',
+      icon: const Icon(Icons.emoji_emotions_outlined),
+      onPressed: () {
+        FocusScope.of(context).unfocus();
+        chatStore.assetsStore.showEmoteMenu = !chatStore.assetsStore.showEmoteMenu;
+      },
+    );
+
     return Observer(
       builder: (context) {
         final matchingEmotes = [
@@ -112,15 +122,8 @@ class ChatBottomBar extends StatelessWidget {
                         enabled: chatStore.auth.isLoggedIn ? true : false,
                         decoration: InputDecoration(
                           contentPadding: const EdgeInsets.fromLTRB(15.0, 10.0, 0.0, 10.0),
-                          suffixIcon: IconButton(
-                            color: chatStore.assetsStore.showEmoteMenu ? Theme.of(context).colorScheme.secondary : null,
-                            tooltip: 'Emote menu',
-                            icon: const Icon(Icons.emoji_emotions_outlined),
-                            onPressed: () {
-                              FocusScope.of(context).unfocus();
-                              chatStore.assetsStore.showEmoteMenu = !chatStore.assetsStore.showEmoteMenu;
-                            },
-                          ),
+                          prefixIcon: chatStore.settings.emoteMenuButtonOnLeft ? emoteMenuButton : null,
+                          suffixIcon: chatStore.settings.emoteMenuButtonOnLeft ? null : emoteMenuButton,
                           hintMaxLines: 1,
                           hintText: chatStore.auth.isLoggedIn
                               ? 'Send a message ${chatStore.settings.chatDelay == 0 ? '' : '(${chatStore.settings.chatDelay.toInt()}s delay)'}'

--- a/lib/screens/settings/chat_settings.dart
+++ b/lib/screens/settings/chat_settings.dart
@@ -90,6 +90,11 @@ class _ChatSettingsState extends State<ChatSettings> {
             onChanged: (newValue) => settingsStore.showBottomBar = newValue,
           ),
           SwitchListTile.adaptive(
+            title: const Text('Emote menu button on left side'),
+            value: settingsStore.emoteMenuButtonOnLeft,
+            onChanged: (newValue) => settingsStore.emoteMenuButtonOnLeft = newValue,
+          ),
+          SwitchListTile.adaptive(
             title: const Text('Landscape chat on left side'),
             value: settingsStore.landscapeChatLeftSide,
             onChanged: (newValue) => settingsStore.landscapeChatLeftSide = newValue,

--- a/lib/screens/settings/stores/settings_store.dart
+++ b/lib/screens/settings/stores/settings_store.dart
@@ -91,6 +91,7 @@ abstract class _SettingsStoreBase with Store {
   static const defaultLandscapeCutout = LandscapeCutoutType.none;
 
   static const defaultShowBottomBar = true;
+  static const defaultEmoteMenuButtonOnLeft = false;
   static const defaultLandscapeChatLeftSide = false;
   static const defaultChatNotificationsOnBottom = false;
   static const defaultChatWidth = 0.3;
@@ -127,6 +128,10 @@ abstract class _SettingsStoreBase with Store {
   @JsonKey(defaultValue: defaultShowBottomBar)
   @observable
   var showBottomBar = defaultShowBottomBar;
+
+  @JsonKey(defaultValue: defaultEmoteMenuButtonOnLeft)
+  @observable
+  var emoteMenuButtonOnLeft = defaultEmoteMenuButtonOnLeft;
 
   @JsonKey(defaultValue: defaultLandscapeChatLeftSide)
   @observable
@@ -202,6 +207,7 @@ abstract class _SettingsStoreBase with Store {
     chatOnlyPreventSleep = defaultChatOnlyPreventSleep;
     autocomplete = defaultAutocomplete;
     showBottomBar = defaultShowBottomBar;
+    emoteMenuButtonOnLeft = defaultEmoteMenuButtonOnLeft;
     landscapeChatLeftSide = defaultLandscapeChatLeftSide;
     chatNotificationsOnBottom = defaultChatNotificationsOnBottom;
     landscapeCutout = defaultLandscapeCutout;

--- a/lib/screens/settings/stores/settings_store.g.dart
+++ b/lib/screens/settings/stores/settings_store.g.dart
@@ -24,6 +24,7 @@ SettingsStore _$SettingsStoreFromJson(Map<String, dynamic> json) =>
       ..chatOnlyPreventSleep = json['chatOnlyPreventSleep'] as bool? ?? true
       ..autocomplete = json['autocomplete'] as bool? ?? true
       ..showBottomBar = json['showBottomBar'] as bool? ?? true
+      ..emoteMenuButtonOnLeft = json['emoteMenuButtonOnLeft'] as bool? ?? false
       ..landscapeChatLeftSide = json['landscapeChatLeftSide'] as bool? ?? false
       ..chatNotificationsOnBottom =
           json['chatNotificationsOnBottom'] as bool? ?? false
@@ -71,6 +72,7 @@ Map<String, dynamic> _$SettingsStoreToJson(SettingsStore instance) =>
       'chatOnlyPreventSleep': instance.chatOnlyPreventSleep,
       'autocomplete': instance.autocomplete,
       'showBottomBar': instance.showBottomBar,
+      'emoteMenuButtonOnLeft': instance.emoteMenuButtonOnLeft,
       'landscapeChatLeftSide': instance.landscapeChatLeftSide,
       'chatNotificationsOnBottom': instance.chatNotificationsOnBottom,
       'landscapeCutout':
@@ -344,6 +346,23 @@ mixin _$SettingsStore on _SettingsStoreBase, Store {
   set showBottomBar(bool value) {
     _$showBottomBarAtom.reportWrite(value, super.showBottomBar, () {
       super.showBottomBar = value;
+    });
+  }
+
+  late final _$emoteMenuButtonOnLeftAtom =
+      Atom(name: '_SettingsStoreBase.emoteMenuButtonOnLeft', context: context);
+
+  @override
+  bool get emoteMenuButtonOnLeft {
+    _$emoteMenuButtonOnLeftAtom.reportRead();
+    return super.emoteMenuButtonOnLeft;
+  }
+
+  @override
+  set emoteMenuButtonOnLeft(bool value) {
+    _$emoteMenuButtonOnLeftAtom.reportWrite(value, super.emoteMenuButtonOnLeft,
+        () {
+      super.emoteMenuButtonOnLeft = value;
     });
   }
 
@@ -776,6 +795,7 @@ chatDelay: ${chatDelay},
 chatOnlyPreventSleep: ${chatOnlyPreventSleep},
 autocomplete: ${autocomplete},
 showBottomBar: ${showBottomBar},
+emoteMenuButtonOnLeft: ${emoteMenuButtonOnLeft},
 landscapeChatLeftSide: ${landscapeChatLeftSide},
 chatNotificationsOnBottom: ${chatNotificationsOnBottom},
 landscapeCutout: ${landscapeCutout},


### PR DESCRIPTION
The emote menu button and "more" button (three dots) are quite close to each other, sometimes resulting in miss-taps. This PR adds an option to have the emote menu button on the left side of the text field instead.

Closes #173