### PR TITLE
Add option to force vertical chat in landscape mode

### DIFF
--- a/lib/screens/channel/channel.dart
+++ b/lib/screens/channel/channel.dart
@@ -166,11 +166,11 @@ class _VideoChatState extends State<VideoChat> {
     final videoChat = Scaffold(
       body: OrientationBuilder(
         builder: (context, orientation) {
-          if (orientation == Orientation.landscape) {
-            SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
+          return Observer(
+            builder: (_) {
+              if (orientation == Orientation.landscape && !settingsStore.landscapeForceVerticalChat) {
+                SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
 
-            return Observer(
-              builder: (context) {
                 final landscapeChat = AnimatedContainer(
                   duration: const Duration(milliseconds: 200),
                   width: _chatStore.expandChat ? MediaQuery.of(context).size.width / 2 : MediaQuery.of(context).size.width * _chatStore.settings.chatWidth,
@@ -224,27 +224,21 @@ class _VideoChatState extends State<VideoChat> {
                           ),
                   ),
                 );
-              },
-            );
-          }
+              }
 
-          SystemChrome.setEnabledSystemUIMode(
-            SystemUiMode.manual,
-            overlays: SystemUiOverlay.values,
-          );
-          return SafeArea(
-            child: Column(
-              children: [
-                Observer(
-                  builder: (_) {
-                    if (!settingsStore.showVideo) return appBar;
-
-                    return AspectRatio(aspectRatio: 16 / 9, child: video);
-                  },
+              SystemChrome.setEnabledSystemUIMode(
+                SystemUiMode.manual,
+                overlays: SystemUiOverlay.values,
+              );
+              return SafeArea(
+                child: Column(
+                  children: [
+                    if (!settingsStore.showVideo) appBar else AspectRatio(aspectRatio: 16 / 9, child: video),
+                    Expanded(child: chat),
+                  ],
                 ),
-                Expanded(child: chat),
-              ],
-            ),
+              );
+            },
           );
         },
       ),

--- a/lib/screens/settings/chat_settings.dart
+++ b/lib/screens/settings/chat_settings.dart
@@ -100,6 +100,7 @@ class _ChatSettingsState extends State<ChatSettings> {
             onChanged: (newValue) => settingsStore.landscapeChatLeftSide = newValue,
           ),
           SwitchListTile.adaptive(
+            isThreeLine: true,
             title: const Text('Force vertical chat in landscape mode'),
             subtitle: const Text('Note: this option is intended for tablets and other larger displays.'),
             value: settingsStore.landscapeForceVerticalChat,

--- a/lib/screens/settings/chat_settings.dart
+++ b/lib/screens/settings/chat_settings.dart
@@ -100,6 +100,12 @@ class _ChatSettingsState extends State<ChatSettings> {
             onChanged: (newValue) => settingsStore.landscapeChatLeftSide = newValue,
           ),
           SwitchListTile.adaptive(
+            title: const Text('Force vertical chat in landscape mode'),
+            subtitle: const Text('Note: this option is intended for tablets and other larger displays.'),
+            value: settingsStore.landscapeForceVerticalChat,
+            onChanged: (newValue) => settingsStore.landscapeForceVerticalChat = newValue,
+          ),
+          SwitchListTile.adaptive(
             isThreeLine: true,
             title: const Text('Notifications on bottom'),
             subtitle: const Text('Shows notifications (e.g., "Message copied") on the bottom of the chat.'),

--- a/lib/screens/settings/stores/settings_store.dart
+++ b/lib/screens/settings/stores/settings_store.dart
@@ -93,6 +93,7 @@ abstract class _SettingsStoreBase with Store {
   static const defaultShowBottomBar = true;
   static const defaultEmoteMenuButtonOnLeft = false;
   static const defaultLandscapeChatLeftSide = false;
+  static const defaultLandscapeForceVerticalChat = false;
   static const defaultChatNotificationsOnBottom = false;
   static const defaultChatWidth = 0.3;
   static const defaultFullScreenChatOverlayOpacity = 0.5;
@@ -134,6 +135,10 @@ abstract class _SettingsStoreBase with Store {
   @JsonKey(defaultValue: defaultLandscapeChatLeftSide)
   @observable
   var landscapeChatLeftSide = defaultLandscapeChatLeftSide;
+
+  @JsonKey(defaultValue: defaultLandscapeForceVerticalChat)
+  @observable
+  var landscapeForceVerticalChat = defaultLandscapeForceVerticalChat;
 
   @JsonKey(defaultValue: defaultChatNotificationsOnBottom)
   @observable
@@ -203,6 +208,7 @@ abstract class _SettingsStoreBase with Store {
     showBottomBar = defaultShowBottomBar;
     emoteMenuButtonOnLeft = defaultEmoteMenuButtonOnLeft;
     landscapeChatLeftSide = defaultLandscapeChatLeftSide;
+    landscapeForceVerticalChat = defaultLandscapeForceVerticalChat;
     chatNotificationsOnBottom = defaultChatNotificationsOnBottom;
     landscapeCutout = defaultLandscapeCutout;
     chatWidth = defaultChatWidth;

--- a/lib/screens/settings/stores/settings_store.g.dart
+++ b/lib/screens/settings/stores/settings_store.g.dart
@@ -26,6 +26,8 @@ SettingsStore _$SettingsStoreFromJson(Map<String, dynamic> json) =>
       ..showBottomBar = json['showBottomBar'] as bool? ?? true
       ..emoteMenuButtonOnLeft = json['emoteMenuButtonOnLeft'] as bool? ?? false
       ..landscapeChatLeftSide = json['landscapeChatLeftSide'] as bool? ?? false
+      ..landscapeForceVerticalChat =
+          json['landscapeForceVerticalChat'] as bool? ?? false
       ..chatNotificationsOnBottom =
           json['chatNotificationsOnBottom'] as bool? ?? false
       ..landscapeCutout = $enumDecodeNullable(
@@ -73,6 +75,7 @@ Map<String, dynamic> _$SettingsStoreToJson(SettingsStore instance) =>
       'showBottomBar': instance.showBottomBar,
       'emoteMenuButtonOnLeft': instance.emoteMenuButtonOnLeft,
       'landscapeChatLeftSide': instance.landscapeChatLeftSide,
+      'landscapeForceVerticalChat': instance.landscapeForceVerticalChat,
       'chatNotificationsOnBottom': instance.chatNotificationsOnBottom,
       'landscapeCutout':
           _$LandscapeCutoutTypeEnumMap[instance.landscapeCutout]!,
@@ -378,6 +381,23 @@ mixin _$SettingsStore on _SettingsStoreBase, Store {
     _$landscapeChatLeftSideAtom.reportWrite(value, super.landscapeChatLeftSide,
         () {
       super.landscapeChatLeftSide = value;
+    });
+  }
+
+  late final _$landscapeForceVerticalChatAtom = Atom(
+      name: '_SettingsStoreBase.landscapeForceVerticalChat', context: context);
+
+  @override
+  bool get landscapeForceVerticalChat {
+    _$landscapeForceVerticalChatAtom.reportRead();
+    return super.landscapeForceVerticalChat;
+  }
+
+  @override
+  set landscapeForceVerticalChat(bool value) {
+    _$landscapeForceVerticalChatAtom
+        .reportWrite(value, super.landscapeForceVerticalChat, () {
+      super.landscapeForceVerticalChat = value;
     });
   }
 
@@ -779,6 +799,7 @@ autocomplete: ${autocomplete},
 showBottomBar: ${showBottomBar},
 emoteMenuButtonOnLeft: ${emoteMenuButtonOnLeft},
 landscapeChatLeftSide: ${landscapeChatLeftSide},
+landscapeForceVerticalChat: ${landscapeForceVerticalChat},
 chatNotificationsOnBottom: ${chatNotificationsOnBottom},
 landscapeCutout: ${landscapeCutout},
 chatWidth: ${chatWidth},


### PR DESCRIPTION
Closes #195.

Adds a new option that forces the chat to be on the bottom when in landscape mode for those that may prefer having the chat on the bottom instead of on the left or right side. This is useful for tablets and other larger displays which have enough vertical space.