### PR TITLE
Update streams/categories lists when resuming after 5 minutes

### DIFF
--- a/lib/screens/home/stream_list/stream_list_store.dart
+++ b/lib/screens/home/stream_list/stream_list_store.dart
@@ -30,6 +30,9 @@ abstract class ListStoreBase with Store {
   /// The pagination cursor for the streams.
   String? _streamsCursor;
 
+  /// The last time the streams were refreshed/updated.
+  var lastTimeRefreshed = DateTime.now();
+
   /// Returns whether or not there are more streams and loading status for pagination.
   @computed
   bool get hasMore => _isLoading == false && _streamsCursor != null;
@@ -130,6 +133,16 @@ abstract class ListStoreBase with Store {
     _streamsCursor = null;
 
     return getStreams();
+  }
+
+  /// Checks the last time the streams were refreshed and updates them if it has been more than 5 minutes.
+  void checkLastTimeRefreshedAndUpdate() {
+    final now = DateTime.now();
+    final difference = now.difference(lastTimeRefreshed);
+
+    if (difference.inMinutes >= 5) refreshStreams();
+
+    lastTimeRefreshed = now;
   }
 
   void dispose() => scrollController?.dispose();

--- a/lib/screens/home/stream_list/streams_list.dart
+++ b/lib/screens/home/stream_list/streams_list.dart
@@ -56,6 +56,8 @@ class _StreamsListState extends State<StreamsList> with AutomaticKeepAliveClient
   Widget build(BuildContext context) {
     super.build(context);
 
+    _listStore.checkLastTimeRefreshedAndUpdate();
+
     return RefreshIndicator(
       onRefresh: () async {
         HapticFeedback.lightImpact();

--- a/lib/screens/home/stream_list/streams_list.dart
+++ b/lib/screens/home/stream_list/streams_list.dart
@@ -29,12 +29,28 @@ class StreamsList extends StatefulWidget {
   State<StreamsList> createState() => _StreamsListState();
 }
 
-class _StreamsListState extends State<StreamsList> with AutomaticKeepAliveClientMixin {
+class _StreamsListState extends State<StreamsList> with AutomaticKeepAliveClientMixin, WidgetsBindingObserver {
   late final _listStore = ListStore(
     authStore: context.read<AuthStore>(),
     twitchApi: context.read<TwitchApi>(),
     listType: widget.listType,
   );
+
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+
+    if (state == AppLifecycleState.resumed) _listStore.checkLastTimeRefreshedAndUpdate();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -116,10 +132,8 @@ class _StreamsListState extends State<StreamsList> with AutomaticKeepAliveClient
   }
 
   @override
-  bool get wantKeepAlive => true;
-
-  @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _listStore.dispose();
     super.dispose();
   }

--- a/lib/screens/home/top/categories/categories.dart
+++ b/lib/screens/home/top/categories/categories.dart
@@ -47,6 +47,8 @@ class _CategoriesState extends State<Categories> with AutomaticKeepAliveClientMi
   Widget build(BuildContext context) {
     super.build(context);
 
+    _categoriesStore.checkLastTimeRefreshedAndUpdate();
+
     return RefreshIndicator(
       onRefresh: () async {
         HapticFeedback.lightImpact();

--- a/lib/screens/home/top/categories/categories.dart
+++ b/lib/screens/home/top/categories/categories.dart
@@ -21,11 +21,27 @@ class Categories extends StatefulWidget {
   State<Categories> createState() => _CategoriesState();
 }
 
-class _CategoriesState extends State<Categories> with AutomaticKeepAliveClientMixin {
+class _CategoriesState extends State<Categories> with AutomaticKeepAliveClientMixin, WidgetsBindingObserver {
   late final _categoriesStore = CategoriesStore(
     authStore: context.read<AuthStore>(),
     twitchApi: context.read<TwitchApi>(),
   );
+
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+
+    if (state == AppLifecycleState.resumed) _categoriesStore.checkLastTimeRefreshedAndUpdate();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -102,5 +118,8 @@ class _CategoriesState extends State<Categories> with AutomaticKeepAliveClientMi
   }
 
   @override
-  bool get wantKeepAlive => true;
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
 }

--- a/lib/screens/home/top/categories/categories_store.dart
+++ b/lib/screens/home/top/categories/categories_store.dart
@@ -19,6 +19,9 @@ abstract class CategoriesStoreBase with Store {
   /// The pagination cursor for the categories.
   String? _categoriesCursor;
 
+  /// The last time the categories were refreshed/updated.
+  var lastTimeRefreshed = DateTime.now();
+
   /// The loading status for pagination.
   @readonly
   bool _isLoading = false;
@@ -73,5 +76,15 @@ abstract class CategoriesStoreBase with Store {
     _categoriesCursor = null;
 
     return getCategories();
+  }
+
+  /// Checks the last time the categories were refreshed and updates them if it has been more than 5 minutes.
+  void checkLastTimeRefreshedAndUpdate() {
+    final now = DateTime.now();
+    final difference = now.difference(lastTimeRefreshed);
+
+    if (difference.inMinutes >= 5) refreshCategories();
+
+    lastTimeRefreshed = now;
   }
 }


### PR DESCRIPTION
Fixes #220

Adds a variable that stores the last time that the streams/categories lists were updated and a method that handles checking the timer to update the list if necessary.

Whenever Frosty is resumed or the list appears (i.e., build), the method `checkLastTimeRefreshedAndUpdate` will be called, which updates the lists if it has been more than 5 minutes since the last call.

