### PR TITLE
Fix badges/emotes in chat switching from old image

### DIFF
--- a/lib/screens/home/stream_list/large_stream_card.dart
+++ b/lib/screens/home/stream_list/large_stream_card.dart
@@ -66,6 +66,7 @@ class LargeStreamCard extends StatelessWidget {
                     streamInfo.thumbnailUrl.replaceFirst('-{width}x{height}', '-${thumbnailWidth}x$thumbnailHeight') +
                         cacheUrlExtension,
                 placeholder: (context, url) => const ColoredBox(color: lightGray, child: LoadingIndicator()),
+                useOldImageOnUrlChange: true,
               ),
             ),
           ),

--- a/lib/screens/home/stream_list/stream_card.dart
+++ b/lib/screens/home/stream_list/stream_card.dart
@@ -50,6 +50,7 @@ class StreamCard extends StatelessWidget {
         imageUrl: streamInfo.thumbnailUrl.replaceFirst('-{width}x{height}', '-${thumbnailWidth}x$thumbnailHeight') +
             cacheUrlExtension,
         placeholder: (context, url) => const ColoredBox(color: lightGray, child: LoadingIndicator()),
+        useOldImageOnUrlChange: true,
       ),
     );
 

--- a/lib/widgets/cached_image.dart
+++ b/lib/widgets/cached_image.dart
@@ -9,6 +9,7 @@ class FrostyCachedNetworkImage extends StatelessWidget {
   final Color? color;
   final BlendMode? colorBlendMode;
   final Widget Function(BuildContext, String)? placeholder;
+  final bool useOldImageOnUrlChange;
   final bool useFade;
   final BoxFit? fit;
 
@@ -21,6 +22,7 @@ class FrostyCachedNetworkImage extends StatelessWidget {
     this.colorBlendMode,
     this.placeholder,
     this.useFade = true,
+    this.useOldImageOnUrlChange = false,
     this.fit,
   }) : super(key: key);
 
@@ -33,7 +35,7 @@ class FrostyCachedNetworkImage extends StatelessWidget {
       color: color,
       colorBlendMode: colorBlendMode,
       placeholder: placeholder,
-      useOldImageOnUrlChange: true,
+      useOldImageOnUrlChange: useOldImageOnUrlChange,
       fadeOutDuration: useFade ? const Duration(milliseconds: 500) : Duration.zero,
       fadeInDuration: useFade ? const Duration(milliseconds: 500) : Duration.zero,
       fadeInCurve: Curves.easeOut,


### PR DESCRIPTION
Due to the `useOldImageOnUrlChange` parameter defaulting to `true` in the new `FrostyCachedImage` widget, badges and emotes in chat would switch from old/random emote images to their actual ones.

This PR adds a new `useOldImageOnUrlChange` parameter that defaults to `false`.