### PR TITLE
Migrate to new Twitch badges endpoint

### DIFF
--- a/lib/apis/twitch_api.dart
+++ b/lib/apis/twitch_api.dart
@@ -90,15 +90,23 @@ class TwitchApi {
   }
 
   /// Returns a map of global Twitch badges to their [Emote] object.
-  Future<Map<String, ChatBadge>> getBadgesGlobal() async {
-    final url = Uri.parse('https://badges.twitch.tv/v1/badges/global/display');
+  Future<Map<String, ChatBadge>> getBadgesGlobal({required Map<String, String> headers}) async {
+    final url = Uri.parse('https://api.twitch.tv/helix/chat/badges/global');
 
-    final response = await _client.get(url);
+    final response = await _client.get(url, headers: headers);
     if (response.statusCode == 200) {
       final result = <String, ChatBadge>{};
-      final decoded = jsonDecode(response.body)['badge_sets'] as Map;
-      decoded.forEach((id, versions) => (versions['versions'] as Map).forEach(
-          (version, badgeInfo) => result['$id/$version'] = ChatBadge.fromTwitch(BadgeInfoTwitch.fromJson(badgeInfo))));
+      final decoded = jsonDecode(response.body)['data'] as List;
+
+      for (final badge in decoded) {
+        final id = badge['set_id'] as String;
+        final versions = badge['versions'] as List;
+
+        for (final version in versions) {
+          final badgeInfo = BadgeInfoTwitch.fromJson(version);
+          result['$id/${badgeInfo.id}'] = ChatBadge.fromTwitch(badgeInfo);
+        }
+      }
 
       return result;
     } else {
@@ -107,15 +115,26 @@ class TwitchApi {
   }
 
   /// Returns a map of a channel's Twitch badges to their [Emote] object.
-  Future<Map<String, ChatBadge>> getBadgesChannel({required String id}) async {
-    final url = Uri.parse('https://badges.twitch.tv/v1/badges/channels/$id/display');
+  Future<Map<String, ChatBadge>> getBadgesChannel({
+    required String id,
+    required Map<String, String> headers,
+  }) async {
+    final url = Uri.parse('https://api.twitch.tv/helix/chat/badges?broadcaster_id=$id');
 
-    final response = await _client.get(url);
+    final response = await _client.get(url, headers: headers);
     if (response.statusCode == 200) {
       final result = <String, ChatBadge>{};
-      final decoded = jsonDecode(response.body)['badge_sets'] as Map;
-      decoded.forEach((id, versions) => (versions['versions'] as Map).forEach(
-          (version, badgeInfo) => result['$id/$version'] = ChatBadge.fromTwitch(BadgeInfoTwitch.fromJson(badgeInfo))));
+      final decoded = jsonDecode(response.body)['data'] as List;
+
+      for (final badge in decoded) {
+        final id = badge['set_id'] as String;
+        final versions = badge['versions'] as List;
+
+        for (final version in versions) {
+          final badgeInfo = BadgeInfoTwitch.fromJson(version);
+          result['$id/${badgeInfo.id}'] = ChatBadge.fromTwitch(badgeInfo);
+        }
+      }
 
       return result;
     } else {

--- a/lib/models/badges.dart
+++ b/lib/models/badges.dart
@@ -11,13 +11,17 @@ class BadgeInfoTwitch {
   @JsonKey(name: 'image_url_4x')
   final String imageUrl4x;
 
+  final String id;
   final String title;
+  final String description;
 
   const BadgeInfoTwitch(
     this.imageUrl1x,
     this.imageUrl2x,
     this.imageUrl4x,
+    this.id,
     this.title,
+    this.description,
   );
 
   factory BadgeInfoTwitch.fromJson(Map<String, dynamic> json) => _$BadgeInfoTwitchFromJson(json);

--- a/lib/models/badges.g.dart
+++ b/lib/models/badges.g.dart
@@ -11,7 +11,9 @@ BadgeInfoTwitch _$BadgeInfoTwitchFromJson(Map<String, dynamic> json) =>
       json['image_url_1x'] as String,
       json['image_url_2x'] as String,
       json['image_url_4x'] as String,
+      json['id'] as String,
       json['title'] as String,
+      json['description'] as String,
     );
 
 BadgeInfoFFZ _$BadgeInfoFFZFromJson(Map<String, dynamic> json) => BadgeInfoFFZ(

--- a/lib/screens/channel/chat/stores/chat_assets_store.dart
+++ b/lib/screens/channel/chat/stores/chat_assets_store.dart
@@ -165,10 +165,11 @@ abstract class ChatAssetsStoreBase with Store {
       Future.wait([
         // Get global badges first, then channel badges to avoid badge conflicts.
         // We want the channel badges to override the global badges.
-        twitchApi.getBadgesGlobal().then((badges) => twitchBadgesToObject.addAll(badges)).then((_) => twitchApi
-            .getBadgesChannel(id: channelId)
-            .then((badges) => twitchBadgesToObject.addAll(badges))
-            .catchError(onError)),
+        twitchApi.getBadgesGlobal(headers: headers).then((badges) => twitchBadgesToObject.addAll(badges)).then((_) =>
+            twitchApi
+                .getBadgesChannel(id: channelId, headers: headers)
+                .then((badges) => twitchBadgesToObject.addAll(badges))
+                .catchError(onError)),
         ffzApi.getBadges().then((badges) => _userToFFZBadges = badges).catchError(onError),
         sevenTVApi.getBadges().then((badges) => _userTo7TVBadges = badges).catchError(onError),
         bttvApi.getBadges().then((badges) => _userToBTTVBadges = badges).catchError(onError),


### PR DESCRIPTION
This PR migrates Twitch badges to utilize the newer and documented endpoint in the latest Twitch API.

Twitch is planning to shut down their legacy badges endpoint, as announced [here](https://discuss.dev.twitch.tv/t/legacy-badges-endpoint-shutdown-details-and-timeline-june-2023/44621).