### PR TITLE
PIP mode for app

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -47,7 +47,12 @@ void main() async {
   autorun((_) => prefs.setString('settings', jsonEncode(settingsStore)));
 
   // Initialize Sentry for crash reporting if enabled.
-  if (settingsStore.sendCrashLogs) await SentryFlutter.init((options) => options.tracesSampleRate = sampleRate);
+  if (settingsStore.sendCrashLogs) {
+    await SentryFlutter.init((options) => {
+          options.tracesSampleRate = sampleRate,
+          options.dsn = '',
+        });
+  }
 
   /// Initialize API services with a common client.
   /// This will prevent every request from creating a new client instance.
@@ -165,7 +170,8 @@ final darkTheme = ThemeData(
       fontWeight: FontWeight.bold,
     ),
   ),
-  bottomNavigationBarTheme: const BottomNavigationBarThemeData(backgroundColor: gray),
+  bottomNavigationBarTheme:
+      const BottomNavigationBarThemeData(backgroundColor: gray),
   colorScheme: ColorScheme.fromSwatch(
     brightness: Brightness.dark,
     primarySwatch: Colors.deepPurple,
@@ -220,7 +226,8 @@ class MyApp extends StatelessWidget {
           locale: DevicePreview.locale(context),
           title: 'Frosty',
           theme: lightTheme,
-          darkTheme: settingsStore.themeType == ThemeType.dark || settingsStore.themeType == ThemeType.system
+          darkTheme: settingsStore.themeType == ThemeType.dark ||
+                  settingsStore.themeType == ThemeType.system
               ? darkTheme
               : oledTheme,
           themeMode: settingsStore.themeType == ThemeType.system

--- a/lib/screens/channel/channel.dart
+++ b/lib/screens/channel/channel.dart
@@ -113,7 +113,12 @@ class _VideoChatState extends State<VideoChat> {
           }
         }
       },
-      onVerticalDragEnd: (details){
+      onHorizontalDragEnd: (details) {
+        if (_videoStore.miniVedioMode) {
+          Navigator.of(context).pop();
+        }
+      },
+      onVerticalDragEnd: (details) {
         _videoStore.setMiniVedioMode(true);
       },
       child: Observer(

--- a/lib/screens/channel/video/video_bar.dart
+++ b/lib/screens/channel/video/video_bar.dart
@@ -25,7 +25,8 @@ class VideoBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final streamTitle = streamInfo.title.trim();
-    final category = streamInfo.gameName.isNotEmpty ? streamInfo.gameName : 'No Category';
+    final category =
+        streamInfo.gameName.isNotEmpty ? streamInfo.gameName : 'No Category';
 
     final streamerName = regexEnglish.hasMatch(streamInfo.userName)
         ? streamInfo.userName
@@ -64,7 +65,11 @@ class VideoBar extends StatelessWidget {
                     streamTitle,
                     overflow: TextOverflow.ellipsis,
                     style: TextStyle(
-                      color: subtitleTextColor ?? Theme.of(context).colorScheme.onSurface.withOpacity(0.8),
+                      color: subtitleTextColor ??
+                          Theme.of(context)
+                              .colorScheme
+                              .onSurface
+                              .withOpacity(0.8),
                       fontWeight: subtitleTextWeight,
                     ),
                   ),
@@ -73,7 +78,11 @@ class VideoBar extends StatelessWidget {
                   const SizedBox(height: 5.0),
                   InkWell(
                     onTap: tappableCategory && streamInfo.gameName.isNotEmpty
-                        ? () => Navigator.push(
+                        ? () {
+                            // remove until this page is the top level
+                            Navigator.popUntil(
+                                context, (route) => route.isFirst);
+                            Navigator.push(
                               context,
                               MaterialPageRoute(
                                 builder: (context) => CategoryStreams(
@@ -81,16 +90,22 @@ class VideoBar extends StatelessWidget {
                                   categoryId: streamInfo.gameId,
                                 ),
                               ),
-                            )
+                            );
+                          }
                         : null,
                     child: Tooltip(
-                      message: 'Category: ${streamInfo.gameName.isNotEmpty ? streamInfo.gameName : 'None'}',
+                      message:
+                          'Category: ${streamInfo.gameName.isNotEmpty ? streamInfo.gameName : 'None'}',
                       showDuration: const Duration(seconds: 3),
                       child: Text(
                         category,
                         overflow: TextOverflow.ellipsis,
                         style: TextStyle(
-                          color: subtitleTextColor ?? Theme.of(context).colorScheme.onSurface.withOpacity(0.8),
+                          color: subtitleTextColor ??
+                              Theme.of(context)
+                                  .colorScheme
+                                  .onSurface
+                                  .withOpacity(0.8),
                           fontWeight: subtitleTextWeight,
                         ),
                       ),

--- a/lib/screens/channel/video/video_store.dart
+++ b/lib/screens/channel/video/video_store.dart
@@ -52,8 +52,10 @@ abstract class VideoStoreBase with Store {
       onMessageReceived: (message) {
         _paused = false;
         if (Platform.isAndroid) pip.setIsPlaying(true);
-        controller?.runJavascript('document.getElementsByTagName("video")[0].muted = false;');
-        controller?.runJavascript('document.getElementsByTagName("video")[0].volume = 1.0;');
+        controller?.runJavascript(
+            'document.getElementsByTagName("video")[0].muted = false;');
+        controller?.runJavascript(
+            'document.getElementsByTagName("video")[0].volume = 1.0;');
       },
     ),
   };
@@ -80,6 +82,10 @@ abstract class VideoStoreBase with Store {
   @readonly
   var _isIPad = false;
 
+  /// For pip mode while in app.
+  @readonly
+  var _miniVedioMode = false;
+
   /// The current stream info, used for displaying relevant info on the overlay.
   @readonly
   StreamTwitch? _streamInfo;
@@ -104,7 +110,8 @@ abstract class VideoStoreBase with Store {
     }
 
     // Initialize the [_overlayTimer] to hide the overlay automatically after 5 seconds.
-    _overlayTimer = Timer(const Duration(seconds: 5), () => _overlayVisible = false);
+    _overlayTimer =
+        Timer(const Duration(seconds: 5), () => _overlayVisible = false);
 
     // Initialize a reaction that will reload the webview whenever the overlay is toggled.
     _disposeOverlayReaction = reaction(
@@ -153,8 +160,22 @@ abstract class VideoStoreBase with Store {
       updateStreamInfo();
 
       _overlayVisible = true;
-      _overlayTimer = Timer(const Duration(seconds: 5), () => _overlayVisible = false);
+      _overlayTimer =
+          Timer(const Duration(seconds: 5), () => _overlayVisible = false);
     }
+  }
+
+  /// Allows to switch between full mode and pip mode.
+  @action
+  void setMiniVedioMode(bool mode) {
+    // close overlay if open for mini vedio mode
+    if (mode) {
+      _overlayTimer.cancel();
+      if (_overlayVisible) {
+        _overlayVisible = false;
+      }
+    }
+    _miniVedioMode = mode;
   }
 
   /// Updates the stream info from the Twitch API.
@@ -163,7 +184,8 @@ abstract class VideoStoreBase with Store {
   @action
   Future<void> updateStreamInfo() async {
     try {
-      _streamInfo = await twitchApi.getStream(userLogin: userLogin, headers: authStore.headersTwitch);
+      _streamInfo = await twitchApi.getStream(
+          userLogin: userLogin, headers: authStore.headersTwitch);
     } catch (e) {
       debugPrint(e.toString());
 
@@ -187,7 +209,8 @@ abstract class VideoStoreBase with Store {
         _overlayVisible = true;
 
         _overlayTimer.cancel();
-        _overlayTimer = Timer(const Duration(seconds: 3), () => _overlayVisible = false);
+        _overlayTimer =
+            Timer(const Duration(seconds: 3), () => _overlayVisible = false);
       }
     }
   }
@@ -204,9 +227,11 @@ abstract class VideoStoreBase with Store {
   void handlePausePlay() {
     try {
       if (_paused) {
-        controller?.runJavascript('document.getElementsByTagName("video")[0].play();');
+        controller?.runJavascript(
+            'document.getElementsByTagName("video")[0].play();');
       } else {
-        controller?.runJavascript('document.getElementsByTagName("video")[0].pause();');
+        controller?.runJavascript(
+            'document.getElementsByTagName("video")[0].pause();');
       }
     } catch (e) {
       debugPrint(e.toString());
@@ -222,7 +247,8 @@ abstract class VideoStoreBase with Store {
       if (Platform.isAndroid) {
         pip.enterPipMode(autoEnter: true);
       } else if (Platform.isIOS) {
-        controller?.runJavascript('document.getElementsByTagName("video")[0].requestPictureInPicture();');
+        controller?.runJavascript(
+            'document.getElementsByTagName("video")[0].requestPictureInPicture();');
       }
     } catch (e) {
       debugPrint(e.toString());

--- a/lib/screens/channel/video/video_store.g.dart
+++ b/lib/screens/channel/video/video_store.g.dart
@@ -71,6 +71,24 @@ mixin _$VideoStore on VideoStoreBase, Store {
     });
   }
 
+  late final _$_miniVedioModeAtom =
+      Atom(name: 'VideoStoreBase._miniVedioMode', context: context);
+
+  bool get miniVedioMode {
+    _$_miniVedioModeAtom.reportRead();
+    return super._miniVedioMode;
+  }
+
+  @override
+  bool get _miniVedioMode => miniVedioMode;
+
+  @override
+  set _miniVedioMode(bool value) {
+    _$_miniVedioModeAtom.reportWrite(value, super._miniVedioMode, () {
+      super._miniVedioMode = value;
+    });
+  }
+
   late final _$_streamInfoAtom =
       Atom(name: 'VideoStoreBase._streamInfo', context: context);
 
@@ -114,6 +132,17 @@ mixin _$VideoStore on VideoStoreBase, Store {
         name: 'VideoStoreBase.handleVideoTap');
     try {
       return super.handleVideoTap();
+    } finally {
+      _$VideoStoreBaseActionController.endAction(_$actionInfo);
+    }
+  }
+
+  @override
+  void setMiniVedioMode(bool mode) {
+    final _$actionInfo = _$VideoStoreBaseActionController.startAction(
+        name: 'VideoStoreBase.setMiniVedioMode');
+    try {
+      return super.setMiniVedioMode(mode);
     } finally {
       _$VideoStoreBaseActionController.endAction(_$actionInfo);
     }

--- a/lib/screens/home/stream_list/large_stream_card.dart
+++ b/lib/screens/home/stream_list/large_stream_card.dart
@@ -12,6 +12,7 @@ import 'package:frosty/widgets/animate_scale.dart';
 import 'package:frosty/widgets/block_report_modal.dart';
 import 'package:frosty/widgets/cached_image.dart';
 import 'package:frosty/widgets/loading_indicator.dart';
+import 'package:frosty/widgets/translucent_overlay_route.dart';
 import 'package:frosty/widgets/uptime.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
@@ -33,7 +34,9 @@ class LargeStreamCard extends StatelessWidget {
     // Get a new URL for the thumbnail every 5 minutes so that the image is updated on refresh.
     // This method adds a random value to the end of the URL to override the cached image.
     final time = DateTime.now();
-    final cacheUrlExtension = time.day.toString() + time.hour.toString() + (time.minute ~/ 5).toString();
+    final cacheUrlExtension = time.day.toString() +
+        time.hour.toString() +
+        (time.minute ~/ 5).toString();
 
     // Calculate the width and height of the thumbnail based on the device width and the stream card size setting.
     // Constraint the resolution to 1920x1080 since that's the max resolution of the Twitch API.
@@ -62,10 +65,12 @@ class LargeStreamCard extends StatelessWidget {
             child: AspectRatio(
               aspectRatio: 16 / 9,
               child: FrostyCachedNetworkImage(
-                imageUrl:
-                    streamInfo.thumbnailUrl.replaceFirst('-{width}x{height}', '-${thumbnailWidth}x$thumbnailHeight') +
-                        cacheUrlExtension,
-                placeholder: (context, url) => const ColoredBox(color: lightGray, child: LoadingIndicator()),
+                imageUrl: streamInfo.thumbnailUrl.replaceFirst(
+                        '-{width}x{height}',
+                        '-${thumbnailWidth}x$thumbnailHeight') +
+                    cacheUrlExtension,
+                placeholder: (context, url) => const ColoredBox(
+                    color: lightGray, child: LoadingIndicator()),
                 useOldImageOnUrlChange: true,
               ),
             ),
@@ -132,16 +137,21 @@ class LargeStreamCard extends StatelessWidget {
         : '${streamInfo.userName} (${streamInfo.userLogin})';
 
     return AnimateScale(
-      onTap: () => Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder: (context) => VideoChat(
-            userId: streamInfo.userId,
-            userName: streamInfo.userName,
-            userLogin: streamInfo.userLogin,
+      onTap: () {
+        // remove until this page is the top level
+        Navigator.popUntil(context, (route) => route.isFirst);
+        // push new VedioChat
+        Navigator.push(
+          context,
+          TranslucentOverlayRoute(
+            builder: (context) => VideoChat(
+              userId: streamInfo.userId,
+              userName: streamInfo.userName,
+              userLogin: streamInfo.userLogin,
+            ),
           ),
-        ),
-      ),
+        );
+      },
       onLongPress: () {
         HapticFeedback.mediumImpact();
 
@@ -157,7 +167,8 @@ class LargeStreamCard extends StatelessWidget {
         );
       },
       child: Padding(
-        padding: EdgeInsets.symmetric(vertical: showThumbnail ? 10.0 : 5.0, horizontal: 15.0),
+        padding: EdgeInsets.symmetric(
+            vertical: showThumbnail ? 10.0 : 5.0, horizontal: 15.0),
         child: Column(
           children: [
             if (showThumbnail) thumbnail,

--- a/lib/screens/home/stream_list/stream_card.dart
+++ b/lib/screens/home/stream_list/stream_card.dart
@@ -35,7 +35,9 @@ class StreamCard extends StatelessWidget {
     // Get a new URL for the thumbnail every 5 minutes so that the image is updated on refresh.
     // This method adds a random value to the end of the URL to override the cached image.
     final time = DateTime.now();
-    final cacheUrlExtension = time.day.toString() + time.hour.toString() + (time.minute ~/ 5).toString();
+    final cacheUrlExtension = time.day.toString() +
+        time.hour.toString() +
+        (time.minute ~/ 5).toString();
 
     // Calculate the width and height of the thumbnail based on the device width and the stream card size setting.
     // Constraint the resolution to 1920x1080 since that's the max resolution of the Twitch API.
@@ -47,9 +49,11 @@ class StreamCard extends StatelessWidget {
     final thumbnail = AspectRatio(
       aspectRatio: 16 / 9,
       child: FrostyCachedNetworkImage(
-        imageUrl: streamInfo.thumbnailUrl.replaceFirst('-{width}x{height}', '-${thumbnailWidth}x$thumbnailHeight') +
+        imageUrl: streamInfo.thumbnailUrl.replaceFirst(
+                '-{width}x{height}', '-${thumbnailWidth}x$thumbnailHeight') +
             cacheUrlExtension,
-        placeholder: (context, url) => const ColoredBox(color: lightGray, child: LoadingIndicator()),
+        placeholder: (context, url) =>
+            const ColoredBox(color: lightGray, child: LoadingIndicator()),
         useOldImageOnUrlChange: true,
       ),
     );
@@ -147,10 +151,13 @@ class StreamCard extends StatelessWidget {
                       )
                   : null,
               child: Tooltip(
-                message: 'Category: ${streamInfo.gameName.isNotEmpty ? streamInfo.gameName : 'None'}',
+                message:
+                    'Category: ${streamInfo.gameName.isNotEmpty ? streamInfo.gameName : 'None'}',
                 preferBelow: false,
                 child: Text(
-                  streamInfo.gameName.isNotEmpty ? streamInfo.gameName : 'No Category',
+                  streamInfo.gameName.isNotEmpty
+                      ? streamInfo.gameName
+                      : 'No Category',
                   overflow: TextOverflow.ellipsis,
                   style: TextStyle(
                     fontSize: subFontSize,
@@ -198,7 +205,8 @@ class StreamCard extends StatelessWidget {
         );
       },
       child: Padding(
-        padding: EdgeInsets.symmetric(vertical: 10.0, horizontal: showThumbnail ? 15.0 : 5.0),
+        padding: EdgeInsets.symmetric(
+            vertical: 10.0, horizontal: showThumbnail ? 15.0 : 5.0),
         child: Row(
           children: [
             if (showThumbnail)

--- a/lib/screens/home/stream_list/stream_card.dart
+++ b/lib/screens/home/stream_list/stream_card.dart
@@ -141,7 +141,10 @@ class StreamCard extends StatelessWidget {
           if (showCategory) ...[
             InkWell(
               onTap: streamInfo.gameName.isNotEmpty
-                  ? () => Navigator.push(
+                  ? () {
+                      // remove until this page is the top level
+                      Navigator.popUntil(context, (route) => route.isFirst);
+                      Navigator.push(
                         context,
                         MaterialPageRoute(
                           builder: (context) => CategoryStreams(
@@ -149,7 +152,8 @@ class StreamCard extends StatelessWidget {
                             categoryId: streamInfo.gameId,
                           ),
                         ),
-                      )
+                      );
+                    }
                   : null,
               child: Tooltip(
                 message:

--- a/lib/screens/home/stream_list/stream_card.dart
+++ b/lib/screens/home/stream_list/stream_card.dart
@@ -13,6 +13,7 @@ import 'package:frosty/widgets/block_report_modal.dart';
 import 'package:frosty/widgets/cached_image.dart';
 import 'package:frosty/widgets/loading_indicator.dart';
 import 'package:frosty/widgets/profile_picture.dart';
+import 'package:frosty/widgets/translucent_overlay_route.dart';
 import 'package:frosty/widgets/uptime.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
@@ -182,7 +183,7 @@ class StreamCard extends StatelessWidget {
     return AnimateScale(
       onTap: () => Navigator.push(
         context,
-        MaterialPageRoute(
+        TranslucentOverlayRoute(
           builder: (context) => VideoChat(
             userId: streamInfo.userId,
             userName: streamInfo.userName,

--- a/lib/screens/home/stream_list/stream_card.dart
+++ b/lib/screens/home/stream_list/stream_card.dart
@@ -181,16 +181,21 @@ class StreamCard extends StatelessWidget {
     );
 
     return AnimateScale(
-      onTap: () => Navigator.push(
-        context,
-        TranslucentOverlayRoute(
-          builder: (context) => VideoChat(
-            userId: streamInfo.userId,
-            userName: streamInfo.userName,
-            userLogin: streamInfo.userLogin,
+      onTap: () {
+        // remove until this page is the top level
+        Navigator.popUntil(context, (route) => route.isFirst);
+        // push new VedioChat
+        Navigator.push(
+          context,
+          TranslucentOverlayRoute(
+            builder: (context) => VideoChat(
+              userId: streamInfo.userId,
+              userName: streamInfo.userName,
+              userLogin: streamInfo.userLogin,
+            ),
           ),
-        ),
-      ),
+        );
+      },
       onLongPress: () {
         HapticFeedback.mediumImpact();
 

--- a/lib/screens/home/top/categories/category_card.dart
+++ b/lib/screens/home/top/categories/category_card.dart
@@ -23,15 +23,19 @@ class CategoryCard extends StatelessWidget {
     final artHeight = (artWidth * (4 / 3)).toInt();
 
     return InkWell(
-      onTap: () => Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder: (context) => CategoryStreams(
-            categoryName: category.name,
-            categoryId: category.id,
+      onTap: () {
+        // remove until this page is the top level
+        Navigator.popUntil(context, (route) => route.isFirst);
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => CategoryStreams(
+              categoryName: category.name,
+              categoryId: category.id,
+            ),
           ),
-        ),
-      ),
+        );
+      },
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 10.0, horizontal: 20.0),
         child: Column(
@@ -42,9 +46,12 @@ class CategoryCard extends StatelessWidget {
                 child: AspectRatio(
                   aspectRatio: 3 / 4,
                   child: FrostyCachedNetworkImage(
-                    imageUrl: category.boxArtUrl
-                        .replaceRange(category.boxArtUrl.lastIndexOf('-') + 1, null, '${artWidth}x$artHeight.jpg'),
-                    placeholder: (context, url) => const ColoredBox(color: lightGray, child: LoadingIndicator()),
+                    imageUrl: category.boxArtUrl.replaceRange(
+                        category.boxArtUrl.lastIndexOf('-') + 1,
+                        null,
+                        '${artWidth}x$artHeight.jpg'),
+                    placeholder: (context, url) => const ColoredBox(
+                        color: lightGray, child: LoadingIndicator()),
                   ),
                 ),
               ),

--- a/lib/widgets/translucent_overlay_route.dart
+++ b/lib/widgets/translucent_overlay_route.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class TranslucentOverlayRoute<T> extends TransitionRoute<T> {
+  final Duration _transitionDuration;
+  final WidgetBuilder builder;
+
+  TranslucentOverlayRoute({
+    required this.builder,
+    Duration transitionDuration = Duration.zero,
+  }) : _transitionDuration = transitionDuration;
+
+  @override
+  Iterable<OverlayEntry> createOverlayEntries() {
+    return [OverlayEntry(builder: builder, maintainState: true)];
+  }
+
+  @override
+  bool get opaque => false;
+
+  @override
+  Duration get transitionDuration => _transitionDuration;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1228,5 +1228,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.18.0 <4.0.0"
+  dart: ">=2.18.0 <3.0.0"
   flutter: ">=3.3.0"


### PR DESCRIPTION
# PIP MODE IN THE APP
Although pip mode was implemented for the Android app. It was missing the mini video mode which is available in the Twitch app.

This is a quality-of-life update to the app.

## Feature implemented:

https://user-images.githubusercontent.com/62815232/234139292-ad15cf5f-a915-4fd8-9e46-0f413ddc3674.mp4

## Feature in the app:

https://user-images.githubusercontent.com/62815232/234141158-956adaa0-b0f2-4fec-98c1-b5d4a6001f44.mp4

## Changes made and How it is implemented:

- To implement this feature I added a new custom route that allows you to overlay the route. 
- It is under the widgets folder named translucent_overlay_route.dart.
- Added a miniVedioMode variable to the video store and regenerated the stores.
- When the user drags down on the video, on_drag_end enables the mini-video mode.
- While in mini video mode when a user taps on the video it goes back to the full screen.
- Finally, while in mini video mode if the user drags horizontally it closes the video component(pops it).
- Finally, before a new video is pushed to the navigator all the routes are poped till the current route.
- This is used for all the routes that use VedioChat, I also implemented this for CategoryStreams to close any current running video before showing CategoryStreams. 

## Additional info:
**This method does not interfere with the default pip mode for Android it still works even if the app is in mini video mode.**

I have never worked with Flutter before so it is completely understandable to reject this feature update. I was unable to implement the hero widget animation for an additional sliding effect between full view and mini view.

## Possible breaking change:

For some reason when I ran it. The SentryFlutter required DSN in its options as well. For now, I have added an empty string, as I don't know what this component of the app does. I highly recommend looking into it if you plan to use this code. 
It can be found at main.dart line 50.
