### PR TITLE
Fix chat autocomplete not updating

### DIFF
--- a/lib/screens/channel/chat/stores/chat_store.dart
+++ b/lib/screens/channel/chat/stores/chat_store.dart
@@ -128,6 +128,9 @@ abstract class ChatStoreBase with Store {
   var _autoScroll = true;
 
   @readonly
+  var _inputText = '';
+
+  @readonly
   var _showSendButton = false;
 
   @readonly
@@ -204,12 +207,13 @@ abstract class ChatStoreBase with Store {
 
     // Add a listener to the textfield that will show/hide the autocomplete bar if focused.
     // Will also rebuild the autocomplete bar when typing, refreshing the results as the user types.
-    textController.addListener(() => _showEmoteAutocomplete =
-        !_showMentionAutocomplete &&
-            textFieldFocusNode.hasFocus &&
-            textController.text.split(' ').last.isNotEmpty);
-
     textController.addListener(() {
+      _inputText = textController.text;
+
+      _showEmoteAutocomplete = !_showMentionAutocomplete &&
+          textFieldFocusNode.hasFocus &&
+          textController.text.split(' ').last.isNotEmpty;
+
       _showSendButton = textController.text.isNotEmpty;
       _showMentionAutocomplete = textFieldFocusNode.hasFocus &&
           textController.text.split(' ').last.startsWith('@');

--- a/lib/screens/channel/chat/stores/chat_store.g.dart
+++ b/lib/screens/channel/chat/stores/chat_store.g.dart
@@ -119,6 +119,24 @@ mixin _$ChatStore on ChatStoreBase, Store {
     });
   }
 
+  late final _$_inputTextAtom =
+      Atom(name: 'ChatStoreBase._inputText', context: context);
+
+  String get inputText {
+    _$_inputTextAtom.reportRead();
+    return super._inputText;
+  }
+
+  @override
+  String get _inputText => inputText;
+
+  @override
+  set _inputText(String value) {
+    _$_inputTextAtom.reportWrite(value, super._inputText, () {
+      super._inputText = value;
+    });
+  }
+
   late final _$_showSendButtonAtom =
       Atom(name: 'ChatStoreBase._showSendButton', context: context);
 

--- a/lib/screens/channel/chat/widgets/chat_bottom_bar.dart
+++ b/lib/screens/channel/chat/widgets/chat_bottom_bar.dart
@@ -39,16 +39,23 @@ class ChatBottomBar extends StatelessWidget {
           ...chatStore.assetsStore.ffzEmotes,
           ...chatStore.assetsStore.sevenTVEmotes
         ]
-            .where((emote) => emote.name.toLowerCase().contains(
-                chatStore.textController.text.split(' ').last.toLowerCase()))
+            .where(
+              (emote) => emote.name.toLowerCase().contains(
+                    chatStore.inputText.split(' ').last.toLowerCase(),
+                  ),
+            )
             .toList();
 
         final matchingChatters = chatStore.chatDetailsStore.chatUsers
-            .where((chatter) => chatter.contains(chatStore.textController.text
-                .split(' ')
-                .last
-                .replaceFirst('@', '')
-                .toLowerCase()))
+            .where(
+              (chatter) => chatter.contains(
+                chatStore.inputText
+                    .split(' ')
+                    .last
+                    .replaceFirst('@', '')
+                    .toLowerCase(),
+              ),
+            )
             .toList();
 
         return Column(


### PR DESCRIPTION
This PR fixes the autocomplete bar not updating after inputting the first character when trying to mention or type emote names.

The root cause is still unclear, but I believe it's due to a recent update to MobX, the package used for state management throughout the app. Based on recent release notes, there were some optimizations and bug fixes. These changes probably caused "bugged/invalid" rebuilds that worked in older versions of Frosty to no longer work in the latest version.

To fix this, I've added an observable `inputText` variable that will keep in sync with the current value of the chat's `TextEditingController`. This will ensure that MobX detects the input changes and accurately rebuilds as the user types. 