### PR TITLE
Fix audio playing in chat-only mode

### DIFF
--- a/lib/screens/channel/video/video.dart
+++ b/lib/screens/channel/video/video.dart
@@ -22,6 +22,10 @@ class _VideoState extends State<Video> with WidgetsBindingObserver {
   @override
   void initState() {
     super.initState();
+    if (widget.videoStore.settingsStore.showVideo) {
+      widget.videoStore.videoWebViewController
+          .loadRequest(Uri.parse(widget.videoStore.videoUrl));
+    }
     WidgetsBinding.instance.addObserver(this);
   }
 
@@ -45,6 +49,9 @@ class _VideoState extends State<Video> with WidgetsBindingObserver {
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    widget.videoStore.videoWebViewController
+        .loadRequest(Uri.parse('about:blank'));
+
     super.dispose();
   }
 }

--- a/lib/screens/channel/video/video_store.dart
+++ b/lib/screens/channel/video/video_store.dart
@@ -258,10 +258,6 @@ abstract class VideoStoreBase with Store {
       });
     }
 
-    // Not ideal, but seems like the only way of disposing of the video properly.
-    // Will both prevent the video from continuing to play when dismissed and closes PiP on iOS.
-    if (Platform.isIOS) videoWebViewController.reload();
-
     _disposeOverlayReaction();
   }
 }

--- a/lib/screens/channel/video/video_store.dart
+++ b/lib/screens/channel/video/video_store.dart
@@ -55,8 +55,7 @@ abstract class VideoStoreBase with Store {
           NavigationDelegate(
             onPageFinished: (_) => initVideo(),
           ),
-        )
-        ..loadRequest(Uri.parse(videoUrl));
+        );
 
   // allowsInlineMediaPlayback: true,
   // initialMediaPlaybackPolicy: AutoMediaPlaybackPolicy.always_allow,
@@ -97,6 +96,22 @@ abstract class VideoStoreBase with Store {
     required this.authStore,
     required this.settingsStore,
   }) {
+    // Initialize the video webview params for iOS to enable video autoplay.
+    if (WebViewPlatform.instance is WebKitWebViewPlatform) {
+      _videoWebViewParams = WebKitWebViewControllerCreationParams(
+        allowsInlineMediaPlayback: true,
+        mediaTypesRequiringUserAction: const <PlaybackMediaTypes>{},
+      );
+    } else {
+      _videoWebViewParams = const PlatformWebViewControllerCreationParams();
+    }
+
+    // Initialize the video webview params for Android to enable video autoplay.
+    if (videoWebViewController.platform is AndroidWebViewController) {
+      (videoWebViewController.platform as AndroidWebViewController)
+          .setMediaPlaybackRequiresUserGesture(false);
+    }
+
     // On Android, enable auto PiP mode (setAutoEnterEnabled) if the device supports it.
     if (Platform.isAndroid) {
       SimplePip.isAutoPipAvailable.then((isAutoPipAvailable) {
@@ -113,22 +128,6 @@ abstract class VideoStoreBase with Store {
       (_) => settingsStore.showOverlay,
       (_) => videoWebViewController.loadRequest(Uri.parse(videoUrl)),
     );
-
-    // Initialize the video webview params for iOS to enable video autoplay.
-    if (WebViewPlatform.instance is WebKitWebViewPlatform) {
-      _videoWebViewParams = WebKitWebViewControllerCreationParams(
-        allowsInlineMediaPlayback: true,
-        mediaTypesRequiringUserAction: const <PlaybackMediaTypes>{},
-      );
-    } else {
-      _videoWebViewParams = const PlatformWebViewControllerCreationParams();
-    }
-
-    // Initialize the video webview params for Android to enable video autoplay.
-    if (videoWebViewController.platform is AndroidWebViewController) {
-      (videoWebViewController.platform as AndroidWebViewController)
-          .setMediaPlaybackRequiresUserGesture(false);
-    }
 
     updateStreamInfo();
   }

--- a/lib/screens/channel/video/video_store.dart
+++ b/lib/screens/channel/video/video_store.dart
@@ -132,14 +132,16 @@ abstract class VideoStoreBase with Store {
   /// Initializes the video webview.
   @action
   Future<void> initVideo() async {
-    // Add event listeners to notify the JavaScript channels when the video plays and pauses.
-    try {
-      videoWebViewController.runJavaScript(
-          'document.getElementsByTagName("video")[0].addEventListener("pause", () => VideoPause.postMessage("video paused"));');
-      videoWebViewController.runJavaScript(
-          'document.getElementsByTagName("video")[0].addEventListener("playing", () => VideoPlaying.postMessage("video playing"));');
-    } catch (e) {
-      debugPrint(e.toString());
+    if (await videoWebViewController.currentUrl() == videoUrl) {
+      // Add event listeners to notify the JavaScript channels when the video plays and pauses.
+      try {
+        videoWebViewController.runJavaScript(
+            'document.getElementsByTagName("video")[0].addEventListener("pause", () => VideoPause.postMessage("video paused"));');
+        videoWebViewController.runJavaScript(
+            'document.getElementsByTagName("video")[0].addEventListener("playing", () => VideoPlaying.postMessage("video playing"));');
+      } catch (e) {
+        debugPrint(e.toString());
+      }
     }
 
     // Determine whether the device is an iPad or not.

--- a/lib/screens/channel/video/video_store.dart
+++ b/lib/screens/channel/video/video_store.dart
@@ -57,9 +57,6 @@ abstract class VideoStoreBase with Store {
           ),
         );
 
-  // allowsInlineMediaPlayback: true,
-  // initialMediaPlaybackPolicy: AutoMediaPlaybackPolicy.always_allow,
-
   /// The timer that handles hiding the overlay automatically
   late Timer _overlayTimer;
 


### PR DESCRIPTION
This PR fixes video playing in the background in chat-only mode.

The issue was caused by the web view still loading the stream URL regardless of whether the video option was on or off.

To fix this, I've moved the URL loading to depend on the widget lifecycle. Therefore, the URL will only be loaded when the `video` widget itself is actually visible. 