### PR TITLE
Add Twitch sub emotes to emote menu

### DIFF
--- a/lib/models/irc.dart
+++ b/lib/models/irc.dart
@@ -413,7 +413,7 @@ class IRCMessage {
                 WidgetSpan(
                   alignment: PlaceholderAlignment.middle,
                   child: InkWell(
-                    onTap: () => _showDetailsBottomSheet(
+                    onTap: () => _showAssetDetailsBottomSheet(
                       context,
                       leading: Stack(
                         alignment: AlignmentDirectional.center,
@@ -559,7 +559,7 @@ class IRCMessage {
     return WidgetSpan(
       alignment: PlaceholderAlignment.middle,
       child: InkWell(
-        onTap: () => _showDetailsBottomSheet(
+        onTap: () => _showAssetDetailsBottomSheet(
           context,
           leading: _createBadgeWidget(
             badge: badge,
@@ -592,15 +592,9 @@ class IRCMessage {
     return WidgetSpan(
       alignment: PlaceholderAlignment.middle,
       child: InkWell(
-        onTap: () => _showDetailsBottomSheet(
+        onTap: () => showEmoteDetailsBottomSheet(
           context,
-          leading: FrostyCachedNetworkImage(
-            imageUrl: emote.url,
-            width: 56,
-          ),
-          url: emote.url,
-          title: emote.name,
-          subtitle: Text(emote.type.toString()),
+          emote: emote,
           launchExternal: launchExternal,
         ),
         child: FrostyCachedNetworkImage(
@@ -641,7 +635,25 @@ class IRCMessage {
     }
   }
 
-  static void _showDetailsBottomSheet(
+  static void showEmoteDetailsBottomSheet(
+    BuildContext context, {
+    required Emote emote,
+    required bool launchExternal,
+  }) {
+    _showAssetDetailsBottomSheet(
+      context,
+      leading: FrostyCachedNetworkImage(
+        imageUrl: emote.url,
+        width: 56,
+      ),
+      url: emote.url,
+      title: emote.name,
+      subtitle: Text(emote.type.toString()),
+      launchExternal: launchExternal,
+    );
+  }
+
+  static void _showAssetDetailsBottomSheet(
     BuildContext context, {
     required Widget leading,
     required String url,

--- a/lib/screens/channel/chat/emote_menu/emote_menu_panel.dart
+++ b/lib/screens/channel/chat/emote_menu/emote_menu_panel.dart
@@ -39,25 +39,37 @@ class EmoteMenuPanel extends StatelessWidget {
           .toList();
 
       return FrostyPageView(
-        headers: ['Global', if (channelEmotes.isNotEmpty) 'Channel'],
+        headers: [if (channelEmotes.isNotEmpty) 'Channel', 'Global'],
         children: [
-          EmoteMenuSection(
-            chatStore: chatStore,
-            emotes: globalEmotes,
-          ),
           if (channelEmotes.isNotEmpty)
             EmoteMenuSection(
               chatStore: chatStore,
               emotes: channelEmotes,
             ),
+          EmoteMenuSection(
+            chatStore: chatStore,
+            emotes: globalEmotes,
+          ),
         ],
       );
     } else {
+      final isSubbed = chatStore.userState.subscriber;
+
+      twitchEmotes?.removeWhere(
+        (key, value) => key.toLowerCase() == chatStore.channelName,
+      );
+
       return FrostyPageView(
         headers:
             twitchEmotes!.keys.map((header) => header.split(' ')[0]).toList(),
         children: twitchEmotes!.entries
-            .map((e) => EmoteMenuSection(chatStore: chatStore, emotes: e.value))
+            .map(
+              (e) => EmoteMenuSection(
+                chatStore: chatStore,
+                emotes: e.value,
+                disabled: e.key.contains('Channel') && !isSubbed,
+              ),
+            )
             .toList(),
       );
     }

--- a/lib/screens/channel/chat/emote_menu/emote_menu_section.dart
+++ b/lib/screens/channel/chat/emote_menu/emote_menu_section.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:frosty/constants.dart';
 import 'package:frosty/models/emotes.dart';
+import 'package:frosty/models/irc.dart';
 import 'package:frosty/screens/channel/chat/stores/chat_store.dart';
 import 'package:frosty/screens/settings/stores/settings_store.dart';
 import 'package:frosty/widgets/cached_image.dart';
@@ -41,22 +42,23 @@ class _EmoteMenuSectionState extends State<EmoteMenuSection>
         onTap: widget.disabled
             ? null
             : () => widget.chatStore.addEmote(widget.emotes[index]),
-        child: Tooltip(
-          message: widget.emotes[index].name,
-          preferBelow: false,
-          child: Padding(
-            padding: const EdgeInsets.all(5.0),
-            child: Center(
-              child: FrostyCachedNetworkImage(
-                imageUrl: widget.emotes[index].url,
-                height:
-                    widget.emotes[index].height?.toDouble() ?? defaultEmoteSize,
-                width: widget.emotes[index].width?.toDouble(),
-                color: widget.disabled
-                    ? const Color.fromRGBO(255, 255, 255, 0.5)
-                    : null,
-                colorBlendMode: widget.disabled ? BlendMode.modulate : null,
-              ),
+        onLongPress: () => IRCMessage.showEmoteDetailsBottomSheet(
+          context,
+          emote: widget.emotes[index],
+          launchExternal: widget.chatStore.settings.launchUrlExternal,
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(5.0),
+          child: Center(
+            child: FrostyCachedNetworkImage(
+              imageUrl: widget.emotes[index].url,
+              height:
+                  widget.emotes[index].height?.toDouble() ?? defaultEmoteSize,
+              width: widget.emotes[index].width?.toDouble(),
+              color: widget.disabled
+                  ? const Color.fromRGBO(255, 255, 255, 0.5)
+                  : null,
+              colorBlendMode: widget.disabled ? BlendMode.modulate : null,
             ),
           ),
         ),

--- a/lib/screens/channel/chat/emote_menu/emote_menu_section.dart
+++ b/lib/screens/channel/chat/emote_menu/emote_menu_section.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:frosty/constants.dart';
 import 'package:frosty/models/emotes.dart';
 import 'package:frosty/models/irc.dart';
@@ -42,11 +43,15 @@ class _EmoteMenuSectionState extends State<EmoteMenuSection>
         onTap: widget.disabled
             ? null
             : () => widget.chatStore.addEmote(widget.emotes[index]),
-        onLongPress: () => IRCMessage.showEmoteDetailsBottomSheet(
-          context,
-          emote: widget.emotes[index],
-          launchExternal: widget.chatStore.settings.launchUrlExternal,
-        ),
+        onLongPress: () {
+          HapticFeedback.lightImpact();
+
+          IRCMessage.showEmoteDetailsBottomSheet(
+            context,
+            emote: widget.emotes[index],
+            launchExternal: widget.chatStore.settings.launchUrlExternal,
+          );
+        },
         child: Padding(
           padding: const EdgeInsets.all(5.0),
           child: Center(

--- a/lib/screens/channel/chat/emote_menu/emote_menu_section.dart
+++ b/lib/screens/channel/chat/emote_menu/emote_menu_section.dart
@@ -9,11 +9,13 @@ import 'package:provider/provider.dart';
 class EmoteMenuSection extends StatefulWidget {
   final ChatStore chatStore;
   final List<Emote> emotes;
+  final bool disabled;
 
   const EmoteMenuSection({
     Key? key,
     required this.chatStore,
     required this.emotes,
+    this.disabled = false,
   }) : super(key: key);
 
   @override
@@ -36,7 +38,9 @@ class _EmoteMenuSectionState extends State<EmoteMenuSection>
                     : 16,
       ),
       itemBuilder: (context, index) => InkWell(
-        onTap: () => widget.chatStore.addEmote(widget.emotes[index]),
+        onTap: widget.disabled
+            ? null
+            : () => widget.chatStore.addEmote(widget.emotes[index]),
         child: Tooltip(
           message: widget.emotes[index].name,
           preferBelow: false,
@@ -48,6 +52,10 @@ class _EmoteMenuSectionState extends State<EmoteMenuSection>
                 height:
                     widget.emotes[index].height?.toDouble() ?? defaultEmoteSize,
                 width: widget.emotes[index].width?.toDouble(),
+                color: widget.disabled
+                    ? const Color.fromRGBO(255, 255, 255, 0.5)
+                    : null,
+                colorBlendMode: widget.disabled ? BlendMode.modulate : null,
               ),
             ),
           ),

--- a/lib/screens/channel/chat/emote_menu/recent_emotes_panel.dart
+++ b/lib/screens/channel/chat/emote_menu/recent_emotes_panel.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:frosty/constants.dart';
+import 'package:frosty/models/irc.dart';
 import 'package:frosty/screens/channel/chat/stores/chat_store.dart';
 import 'package:frosty/screens/settings/stores/settings_store.dart';
 import 'package:frosty/widgets/alert_message.dart';
@@ -50,25 +52,30 @@ class RecentEmotesPanel extends StatelessWidget {
                   onTap: matchingEmotes.isNotEmpty
                       ? () => chatStore.addEmote(emote)
                       : null,
-                  child: Tooltip(
-                    message: emote.name,
-                    preferBelow: false,
-                    child: Padding(
-                      padding: const EdgeInsets.all(8),
-                      child: Center(
-                        child: FrostyCachedNetworkImage(
-                          imageUrl: matchingEmotes.isNotEmpty
-                              ? matchingEmotes.first.url
-                              : emote.url,
-                          color: matchingEmotes.isNotEmpty
-                              ? null
-                              : const Color.fromRGBO(255, 255, 255, 0.5),
-                          colorBlendMode: matchingEmotes.isNotEmpty
-                              ? null
-                              : BlendMode.modulate,
-                          height: emote.height?.toDouble() ?? defaultEmoteSize,
-                          width: emote.width?.toDouble(),
-                        ),
+                  onLongPress: () {
+                    HapticFeedback.lightImpact();
+
+                    IRCMessage.showEmoteDetailsBottomSheet(
+                      context,
+                      emote: emote,
+                      launchExternal: chatStore.settings.launchUrlExternal,
+                    );
+                  },
+                  child: Padding(
+                    padding: const EdgeInsets.all(8),
+                    child: Center(
+                      child: FrostyCachedNetworkImage(
+                        imageUrl: matchingEmotes.isNotEmpty
+                            ? matchingEmotes.first.url
+                            : emote.url,
+                        color: matchingEmotes.isNotEmpty
+                            ? null
+                            : const Color.fromRGBO(255, 255, 255, 0.5),
+                        colorBlendMode: matchingEmotes.isNotEmpty
+                            ? null
+                            : BlendMode.modulate,
+                        height: emote.height?.toDouble() ?? defaultEmoteSize,
+                        width: emote.width?.toDouble(),
                       ),
                     ),
                   ),

--- a/lib/screens/channel/chat/stores/chat_assets_store.dart
+++ b/lib/screens/channel/chat/stores/chat_assets_store.dart
@@ -219,15 +219,26 @@ abstract class ChatAssetsStoreBase with Store {
     for (final emoteSet in userEmotes) {
       if (emoteSet.isNotEmpty) {
         if (emoteSet.first.type == EmoteType.twitchSub) {
-          final owner = await twitchApi.getUser(
-            id: emoteSet.first.ownerId,
-            headers: headers,
-          );
-          _userEmoteSectionToEmotes.update(
-            owner.displayName,
-            (existingEmoteSet) => [...existingEmoteSet, ...emoteSet],
-            ifAbsent: () => emoteSet,
-          );
+          final ownerId = emoteSet.first.ownerId;
+
+          // Check for tuurbo emote sets (e.g., monkey set)
+          if (ownerId == 'twitch') {
+            _userEmoteSectionToEmotes.update(
+              'Global Emotes',
+              (existingEmoteSet) => [...existingEmoteSet, ...emoteSet],
+              ifAbsent: () => emoteSet,
+            );
+          } else {
+            final owner = await twitchApi.getUser(
+              id: ownerId,
+              headers: headers,
+            );
+            _userEmoteSectionToEmotes.update(
+              owner.displayName,
+              (existingEmoteSet) => [...existingEmoteSet, ...emoteSet],
+              ifAbsent: () => emoteSet,
+            );
+          }
         } else if (emoteSet.first.type == EmoteType.twitchGlobal) {
           _userEmoteSectionToEmotes.update(
             'Global Emotes',

--- a/lib/screens/channel/chat/stores/chat_assets_store.dart
+++ b/lib/screens/channel/chat/stores/chat_assets_store.dart
@@ -155,7 +155,15 @@ abstract class ChatAssetsStoreBase with Store {
         twitchApi.getEmotesGlobal(headers: headers).catchError(onError),
         twitchApi
             .getEmotesChannel(id: channelId, headers: headers)
-            .catchError(onError),
+            .then((emotes) {
+          _userEmoteSectionToEmotes.update(
+            'Channel Emotes',
+            (existingEmoteSet) => [...existingEmoteSet, ...emotes],
+            ifAbsent: () => emotes.toList(),
+          );
+
+          return emotes;
+        }).catchError(onError),
         sevenTVApi.getEmotesGlobal().catchError(onError),
         sevenTVApi.getEmotesChannel(id: channelId).catchError(onError),
         ffzApi.getRoomInfo(id: channelId).then((ffzRoom) {
@@ -221,7 +229,7 @@ abstract class ChatAssetsStoreBase with Store {
         if (emoteSet.first.type == EmoteType.twitchSub) {
           final ownerId = emoteSet.first.ownerId;
 
-          // Check for tuurbo emote sets (e.g., monkey set)
+          // Check for tuurbo emote sets (e.g., monkey set).
           if (ownerId == 'twitch') {
             _userEmoteSectionToEmotes.update(
               'Global Emotes',

--- a/lib/screens/channel/chat/stores/chat_store.dart
+++ b/lib/screens/channel/chat/stores/chat_store.dart
@@ -226,7 +226,7 @@ abstract class ChatStoreBase with Store {
     // The IRC data can contain more than one message separated by CRLF.
     // To account for this, split by CRLF, then loop and process each message.
     for (final message in data.trimRight().split('\r\n')) {
-      debugPrint('$message\n');
+      // debugPrint('$message\n');
       if (message.startsWith('@')) {
         final parsedIRCMessage =
             IRCMessage.fromString(message, userLogin: auth.user.details?.login);

--- a/lib/screens/channel/chat/stores/chat_store.dart
+++ b/lib/screens/channel/chat/stores/chat_store.dart
@@ -226,7 +226,7 @@ abstract class ChatStoreBase with Store {
     // The IRC data can contain more than one message separated by CRLF.
     // To account for this, split by CRLF, then loop and process each message.
     for (final message in data.trimRight().split('\r\n')) {
-      // debugPrint('$message\n');
+      debugPrint('$message\n');
       if (message.startsWith('@')) {
         final parsedIRCMessage =
             IRCMessage.fromString(message, userLogin: auth.user.details?.login);


### PR DESCRIPTION
Closes #197 and #245.

This PR adds the sub emotes of the current channel to the emote menu under the Twitch -> Channel tab. The emotes will be disabled if you are not subscribed to the channel.

Also fixes a case where enabling turbo emotes would prevent emotes from subbed channels from showing in the emote menu.

Additionally, emotes in the emote menu now use the new tooltip by long-pressing the emote.

