### PR TITLE
Hide subtitles on iOS

### DIFF
--- a/lib/screens/channel/video/video_store.dart
+++ b/lib/screens/channel/video/video_store.dart
@@ -144,10 +144,16 @@ abstract class VideoStoreBase with Store {
       // Add event listeners to notify the JavaScript channels when the video plays and pauses.
       try {
         videoWebViewController.runJavaScript(
-          'document.getElementsByTagName("video")[0].addEventListener("pause", () => VideoPause.postMessage("video paused"));',
+          '''document.getElementsByTagName("video")[0].addEventListener("pause", () => {
+              VideoPause.postMessage("video paused");
+              document.getElementsByTagName("video")[0].textTracks[0].mode = "hidden";
+          });''',
         );
         videoWebViewController.runJavaScript(
-          'document.getElementsByTagName("video")[0].addEventListener("playing", () => VideoPlaying.postMessage("video playing"));',
+          '''document.getElementsByTagName("video")[0].addEventListener("playing", () => {
+              VideoPlaying.postMessage("video playing")
+              document.getElementsByTagName("video")[0].textTracks[0].mode = "hidden";
+          });''',
         );
       } catch (e) {
         debugPrint(e.toString());


### PR DESCRIPTION
Fixes #279.

This PR simply adds a JavaScript line that hides subtitles on the web video player. This is an iOS-specific fix, where subtitles/cc are enabled by default.