### PR TITLE
Fix 7TV emotes not using custom names

### DIFF
--- a/lib/apis/seventv_api.dart
+++ b/lib/apis/seventv_api.dart
@@ -17,7 +17,7 @@ class SevenTVApi {
     final response = await _client.get(url);
     if (response.statusCode == 200) {
       final decoded = jsonDecode(response.body)['emotes'] as List;
-      final emotes = decoded.map((emote) => Emote7TV.fromJson(emote['data']));
+      final emotes = decoded.map((emote) => Emote7TV.fromJson(emote));
 
       return emotes
           .map((emote) => Emote.from7TV(emote, EmoteType.sevenTVGlobal))
@@ -34,7 +34,7 @@ class SevenTVApi {
     final response = await _client.get(url);
     if (response.statusCode == 200) {
       final decoded = jsonDecode(response.body)['emote_set']['emotes'] as List;
-      final emotes = decoded.map((emote) => Emote7TV.fromJson(emote['data']));
+      final emotes = decoded.map((emote) => Emote7TV.fromJson(emote));
 
       return emotes
           .map((emote) => Emote.from7TV(emote, EmoteType.sevenTVChannel))

--- a/lib/models/emotes.dart
+++ b/lib/models/emotes.dart
@@ -108,19 +108,37 @@ class EmoteFFZ {
 @JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
 class Emote7TV {
   final String id;
+
+  /// Will be non-null if a custom emote name is used.
+  final String? name;
+  final Emote7TVData data;
+
+  const Emote7TV(
+    this.id,
+    this.name,
+    this.data,
+  );
+
+  factory Emote7TV.fromJson(Map<String, dynamic> json) =>
+      _$Emote7TVFromJson(json);
+}
+
+@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+class Emote7TVData {
+  final String id;
   final String name;
   final List<String>? tags;
   final Emote7TVHost host;
 
-  const Emote7TV(
+  const Emote7TVData(
     this.id,
     this.name,
     this.tags,
     this.host,
   );
 
-  factory Emote7TV.fromJson(Map<String, dynamic> json) =>
-      _$Emote7TVFromJson(json);
+  factory Emote7TVData.fromJson(Map<String, dynamic> json) =>
+      _$Emote7TVDataFromJson(json);
 }
 
 @JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
@@ -202,17 +220,17 @@ class Emote {
       );
 
   factory Emote.from7TV(Emote7TV emote, EmoteType type) {
-    final url = emote.host.url;
+    final url = emote.data.host.url;
     // Flutter doesn't support AVIF yet.
-    final file = emote.host.files.reversed.firstWhere(
+    final file = emote.data.host.files.reversed.firstWhere(
       (file) => file.format != 'AVIF' && file.name.contains('4x'),
     );
 
     return Emote(
-      name: emote.name,
-      width: emote.host.files.first.width,
-      height: emote.host.files.first.height,
-      zeroWidth: emote.tags?.contains('zerowidth') ?? false,
+      name: emote.name ?? emote.data.name,
+      width: emote.data.host.files.first.width,
+      height: emote.data.host.files.first.height,
+      zeroWidth: emote.data.tags?.contains('zerowidth') ?? false,
       url: 'https:$url/${file.name}',
       type: type,
     );

--- a/lib/models/emotes.dart
+++ b/lib/models/emotes.dart
@@ -108,9 +108,7 @@ class EmoteFFZ {
 @JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
 class Emote7TV {
   final String id;
-
-  /// Will be non-null if a custom emote name is used.
-  final String? name;
+  final String name;
   final Emote7TVData data;
 
   const Emote7TV(
@@ -177,6 +175,7 @@ class Emote7TVFile {
 @JsonSerializable()
 class Emote {
   final String name;
+  final String? realName;
   final int? width;
   final int? height;
   final bool zeroWidth;
@@ -186,6 +185,7 @@ class Emote {
 
   const Emote({
     required this.name,
+    this.realName,
     this.width,
     this.height,
     required this.zeroWidth,
@@ -227,7 +227,8 @@ class Emote {
     );
 
     return Emote(
-      name: emote.name ?? emote.data.name,
+      name: emote.name,
+      realName: emote.name != emote.data.name ? emote.data.name : null,
       width: emote.data.host.files.first.width,
       height: emote.data.host.files.first.height,
       zeroWidth: emote.data.tags?.contains('zerowidth') ?? false,

--- a/lib/models/emotes.g.dart
+++ b/lib/models/emotes.g.dart
@@ -53,6 +53,12 @@ EmoteFFZ _$EmoteFFZFromJson(Map<String, dynamic> json) => EmoteFFZ(
 
 Emote7TV _$Emote7TVFromJson(Map<String, dynamic> json) => Emote7TV(
       json['id'] as String,
+      json['name'] as String?,
+      Emote7TVData.fromJson(json['data'] as Map<String, dynamic>),
+    );
+
+Emote7TVData _$Emote7TVDataFromJson(Map<String, dynamic> json) => Emote7TVData(
+      json['id'] as String,
       json['name'] as String,
       (json['tags'] as List<dynamic>?)?.map((e) => e as String).toList(),
       Emote7TVHost.fromJson(json['host'] as Map<String, dynamic>),

--- a/lib/models/emotes.g.dart
+++ b/lib/models/emotes.g.dart
@@ -53,7 +53,7 @@ EmoteFFZ _$EmoteFFZFromJson(Map<String, dynamic> json) => EmoteFFZ(
 
 Emote7TV _$Emote7TVFromJson(Map<String, dynamic> json) => Emote7TV(
       json['id'] as String,
-      json['name'] as String?,
+      json['name'] as String,
       Emote7TVData.fromJson(json['data'] as Map<String, dynamic>),
     );
 
@@ -80,6 +80,7 @@ Emote7TVFile _$Emote7TVFileFromJson(Map<String, dynamic> json) => Emote7TVFile(
 
 Emote _$EmoteFromJson(Map<String, dynamic> json) => Emote(
       name: json['name'] as String,
+      realName: json['realName'] as String?,
       width: json['width'] as int?,
       height: json['height'] as int?,
       zeroWidth: json['zeroWidth'] as bool,
@@ -90,6 +91,7 @@ Emote _$EmoteFromJson(Map<String, dynamic> json) => Emote(
 
 Map<String, dynamic> _$EmoteToJson(Emote instance) => <String, dynamic>{
       'name': instance.name,
+      'realName': instance.realName,
       'width': instance.width,
       'height': instance.height,
       'zeroWidth': instance.zeroWidth,

--- a/lib/models/irc.dart
+++ b/lib/models/irc.dart
@@ -648,7 +648,9 @@ class IRCMessage {
         width: 56,
       ),
       url: emote.url,
-      title: emote.name,
+      title: emote.realName != null
+          ? '${emote.name} (${emote.realName})'
+          : emote.name,
       subtitle: Text(emote.type.toString()),
       launchExternal: launchExternal,
     );


### PR DESCRIPTION
Fixes (#289).

This PR fixes a case where 7TV emotes were not being shown/parsed correctly if the channel had set a custom name for that emote.

With the 7TV V3 API, emotes have 2 different name fields, the first on the top level as `name` and the second in `data` -> `name`. The former will change automatically if the channel has set a custom name for it, while the latter will not change and is the "real" name of the emote.

I mistakenly thought the latter had the behavior of the former and used that field. Now, the former field will be used and checked to see if we should show the real name in the emote details.