### PR TITLE
Fix 7TV zero-width emotes not working

### DIFF
--- a/lib/models/emotes.dart
+++ b/lib/models/emotes.dart
@@ -109,10 +109,12 @@ class EmoteFFZ {
 class Emote7TV {
   final String id;
   final String name;
+  final int flags;
   final Emote7TVData data;
 
   const Emote7TV(
     this.id,
+    this.flags,
     this.name,
     this.data,
   );
@@ -231,7 +233,7 @@ class Emote {
       realName: emote.name != emote.data.name ? emote.data.name : null,
       width: emote.data.host.files.first.width,
       height: emote.data.host.files.first.height,
-      zeroWidth: emote.data.tags?.contains('zerowidth') ?? false,
+      zeroWidth: emote.flags == 1,
       url: 'https:$url/${file.name}',
       type: type,
     );

--- a/lib/models/emotes.g.dart
+++ b/lib/models/emotes.g.dart
@@ -53,6 +53,7 @@ EmoteFFZ _$EmoteFFZFromJson(Map<String, dynamic> json) => EmoteFFZ(
 
 Emote7TV _$Emote7TVFromJson(Map<String, dynamic> json) => Emote7TV(
       json['id'] as String,
+      json['flags'] as int,
       json['name'] as String,
       Emote7TVData.fromJson(json['data'] as Map<String, dynamic>),
     );


### PR DESCRIPTION
Fixes #290.

This PR makes it so that we parse the `flags` field from the 7TV V3 API to check if an emote is zero-width

Previously, the `tags` field was being parsed to determine if it was zero-width. Turns out, not all zero-width emotes have this set (the tags are probably for something else, like for rendering/filtering on clients).

It doesn't seem to be documented, but based on looking at different emotes in the responses, the `flags` field appears to be responsible for the zero-width ability. If set to `0` it means a normal emote and `1` means zero-width. This field is now checked to determine if an emote is zero-width.