### PR TITLE
fix: update 7tv badges endpoint

### DIFF
--- a/lib/apis/seventv_api.dart
+++ b/lib/apis/seventv_api.dart
@@ -47,7 +47,7 @@ class SevenTVApi {
   /// Returns a map of user IDS to a list of their 7TV badges.
   Future<Map<String, List<ChatBadge>>> getBadges() async {
     final url =
-        Uri.parse('https://api.7tv.app/v2/badges?user_identifier=twitch_id');
+        Uri.parse('https://7tv.io/v2/cosmetics?user_identifier=twitch_id');
 
     final response = await _client.get(url);
     if (response.statusCode == 200) {


### PR DESCRIPTION
This is the new endpoint as the old one will be deprecated.