### PR TITLE
Fix recent emotes not clearing

### DIFF
--- a/lib/screens/channel/chat/details/chat_details.dart
+++ b/lib/screens/channel/chat/details/chat_details.dart
@@ -132,7 +132,11 @@ class ChatDetails extends StatelessWidget {
             child: const Text('Cancel'),
           ),
           TextButton(
-            onPressed: Navigator.of(context).pop,
+            onPressed: () {
+              chatStore.assetsStore.recentEmotes.clear();
+
+              Navigator.pop(context);
+            },
             child: const Text('Yes'),
           ),
         ],


### PR DESCRIPTION
This PR fixes the "Recent" panel in the emote menu not clearing.

During the Material 3 refactor, I forgot to handle the clear behavior when confirming on the alert dialog. I've simply added back the clear method when tapping "Yes" on the alert dialog.

I've also wrapped the recent emote panel with the `Observer` widget so that the clear will be properly rebuilt.