### PR TITLE
Fix quality selection and latency stats using an asyncQuerySelector

### DIFF
--- a/lib/screens/channel/video/video_store.dart
+++ b/lib/screens/channel/video/video_store.dart
@@ -340,8 +340,8 @@ abstract class VideoStoreBase with Store {
           });''',
         );
         if (settingsStore.showOverlay) {
-          _hideDefaultOverlay();
-          _listenOnLatencyChanges();
+          await _hideDefaultOverlay();
+          await _listenOnLatencyChanges();
         }
       } catch (e) {
         debugPrint(e.toString());

--- a/lib/screens/channel/video/video_store.dart
+++ b/lib/screens/channel/video/video_store.dart
@@ -190,14 +190,27 @@ abstract class VideoStoreBase with Store {
     try {
       await videoWebViewController.runJavaScript('''
         {
-          document.querySelector('[data-a-target="player-settings-button"]').click();
-          document.querySelector('[data-a-target="player-settings-menu-item-quality"]').click();
-          const qualities = [...document.querySelectorAll('[data-a-target="player-settings-submenu-quality-option"] label div')].map((el) => el.textContent);
-          document.querySelector('.tw-drop-down-menu-item-figure').click();
-          document.querySelector('[data-a-target="player-settings-menu"] [role="menuitem"] button').click();
-          StreamQualities.postMessage(JSON.stringify(qualities));
+          const delay = () => new Promise(resolve => setTimeout(resolve, 50));
+          (async () => {
+            document.querySelector('[data-a-target="player-settings-button"]').click();
+            await delay();
+            if (!document.querySelector('[data-a-target="player-settings-menu-item-quality"]')) {
+              // sometimes the menu doesn't appear on first tap :/
+              document.querySelector('[data-a-target="player-settings-button"]').click();
+              await delay();
+            }
+            document.querySelector('[data-a-target="player-settings-menu-item-quality"]').click();
+            await delay();
+            const qualities = [...document.querySelectorAll('[data-a-target="player-settings-submenu-quality-option"] label div')].map((el) => el.textContent);
+            StreamQualities.postMessage(JSON.stringify(qualities));
+            document.querySelector('.tw-drop-down-menu-item-figure').click();
+            await delay();
+            document.querySelector('[data-a-target="player-settings-menu"] [role="menuitem"] button').click();
+          })();
         }
       ''');
+      // extra delay to wait for async javascript
+      await Future.delayed(const Duration(milliseconds: 250));
     } catch (e) {
       debugPrint(e.toString());
     }
@@ -209,13 +222,27 @@ abstract class VideoStoreBase with Store {
         _availableStreamQualities.indexOf(newStreamQuality);
     await videoWebViewController.runJavaScript('''
         {
-          document.querySelector('[data-a-target="player-settings-button"]').click();
-          document.querySelector('[data-a-target="player-settings-menu-item-quality"]').click();
-          [...document.querySelectorAll('[data-a-target="player-settings-submenu-quality-option"] input')][$indexOfStreamQuality].click();
-          document.querySelector('.tw-drop-down-menu-item-figure').click();
-          document.querySelector('[data-a-target="player-settings-menu"] [role="menuitem"] button').click();
+          const delay = () => new Promise(resolve => setTimeout(resolve, 50));
+          (async () => {
+            document.querySelector('[data-a-target="player-settings-button"]').click();
+            await delay();
+            if (!document.querySelector('[data-a-target="player-settings-menu-item-quality"]')) {
+              // sometimes the menu doesn't appear on first tap :/
+              document.querySelector('[data-a-target="player-settings-button"]').click();
+              await delay();
+            }
+            document.querySelector('[data-a-target="player-settings-menu-item-quality"]').click();
+            await delay();
+            [...document.querySelectorAll('[data-a-target="player-settings-submenu-quality-option"] input')][$indexOfStreamQuality].click();
+            await delay();
+            document.querySelector('.tw-drop-down-menu-item-figure').click();
+            await delay();
+            document.querySelector('[data-a-target="player-settings-menu"] [role="menuitem"] button').click();
+          })();
         }
       ''');
+    // extra delay to wait for async javascript
+    await Future.delayed(const Duration(milliseconds: 300));
     _streamQuality = newStreamQuality;
   }
 

--- a/lib/screens/channel/video/video_store.g.dart
+++ b/lib/screens/channel/video/video_store.g.dart
@@ -100,21 +100,21 @@ mixin _$VideoStore on VideoStoreBase, Store {
     });
   }
 
-  late final _$_streamQualityAtom =
-      Atom(name: 'VideoStoreBase._streamQuality', context: context);
+  late final _$_streamQualityIndexAtom =
+      Atom(name: 'VideoStoreBase._streamQualityIndex', context: context);
 
-  String get streamQuality {
-    _$_streamQualityAtom.reportRead();
-    return super._streamQuality;
+  int get streamQualityIndex {
+    _$_streamQualityIndexAtom.reportRead();
+    return super._streamQualityIndex;
   }
 
   @override
-  String get _streamQuality => streamQuality;
+  int get _streamQualityIndex => streamQualityIndex;
 
   @override
-  set _streamQuality(String value) {
-    _$_streamQualityAtom.reportWrite(value, super._streamQuality, () {
-      super._streamQuality = value;
+  set _streamQualityIndex(int value) {
+    _$_streamQualityIndexAtom.reportWrite(value, super._streamQualityIndex, () {
+      super._streamQualityIndex = value;
     });
   }
 
@@ -152,6 +152,15 @@ mixin _$VideoStore on VideoStoreBase, Store {
   Future<void> setStreamQuality(String newStreamQuality) {
     return _$setStreamQualityAsyncAction
         .run(() => super.setStreamQuality(newStreamQuality));
+  }
+
+  late final _$_setStreamQualityIndexAsyncAction =
+      AsyncAction('VideoStoreBase._setStreamQualityIndex', context: context);
+
+  @override
+  Future<void> _setStreamQualityIndex(int newStreamQualityIndex) {
+    return _$_setStreamQualityIndexAsyncAction
+        .run(() => super._setStreamQualityIndex(newStreamQualityIndex));
   }
 
   late final _$initVideoAsyncAction =


### PR DESCRIPTION
I was looking into why stream qualities weren't displaying for me on the custom overlay, and found it was occurring because after clicking the :gear: settings button on the player, the menu doesn't appear until a split second later.

To fix this, I've updated the stream quality methods to use a new `asyncQuerySelector` instead of `document.querySelector`. I had to apply the same fix to the latency stats to ensure consistent stream quality behaviour, as they also interact with the settings menu.

This change to using async JS code means that awaiting for `videoWebViewController.runJavaScript` no longer guarantees that the previous task actually completed, which was causing issues with the current `defaultToHighestQuality` logic. I resolved this by updating this setting to call a new `_setStreamQualityIndex(1)` instead. This also has the benefit of not "flashing" the settings menu twice when using `defaultToHighestQuality` without the custom overlay.

Fixes https://github.com/tommyxchow/frosty/issues/338 (and maybe https://github.com/tommyxchow/frosty/issues/334?)