### PR TITLE
Add quick toggle for chat-only mode

### DIFF
--- a/lib/screens/channel/chat/details/chat_details.dart
+++ b/lib/screens/channel/chat/details/chat_details.dart
@@ -1,4 +1,3 @@
-
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:frosty/main.dart';
@@ -212,6 +211,12 @@ class ChatDetails extends StatelessWidget {
 
           chatStore.updateNotification('Badges and emotes refreshed');
         },
+      ),
+      ListTile(
+        leading: const Icon(Icons.chat_rounded),
+        title: const Text('Toggle chat-only mode'),
+        onTap: () =>
+            chatStore.settings.showVideo = !chatStore.settings.showVideo,
       ),
       ListTile(
         leading: const Icon(Icons.settings_outlined),

--- a/lib/screens/channel/chat/stores/chat_store.dart
+++ b/lib/screens/channel/chat/stores/chat_store.dart
@@ -181,14 +181,18 @@ abstract class ChatStoreBase with Store {
     messageBuffer
         .add(IRCMessage.createNotice(message: 'Connecting to chat...'));
 
-    if (settings.chatDelay > 0) {
-      messageBuffer.add(
-        IRCMessage.createNotice(
-          message:
-              'Waiting ${settings.chatDelay.toInt()} ${settings.chatDelay == 1.0 ? 'second' : 'seconds'} due to message delay setting...',
-        ),
-      );
-    }
+    reactions.add(
+      autorun((_) {
+        if (settings.chatDelay > 0 && settings.showVideo) {
+          messageBuffer.add(
+            IRCMessage.createNotice(
+              message:
+                  'Waiting ${settings.chatDelay.toInt()} ${settings.chatDelay == 1.0 ? 'second' : 'seconds'} due to message delay setting...',
+            ),
+          );
+        }
+      }),
+    );
 
     connectToChat();
 
@@ -391,7 +395,9 @@ abstract class ChatStoreBase with Store {
 
     _sevenTVChannelListener = _sevenTVChannel?.stream.listen(
       (data) => Future.delayed(
-        Duration(seconds: settings.chatDelay.toInt()),
+        settings.showVideo
+            ? Duration(seconds: settings.chatDelay.toInt())
+            : Duration.zero,
         () {
           debugPrint(data);
           final decoded = jsonDecode(data);
@@ -449,7 +455,9 @@ abstract class ChatStoreBase with Store {
     // Listen for new messages and forward them to the handler.
     _channelListener = _channel?.stream.listen(
       (data) => Future.delayed(
-        Duration(seconds: settings.chatDelay.toInt()),
+        settings.showVideo
+            ? Duration(seconds: settings.chatDelay.toInt())
+            : Duration.zero,
         () => _handleIRCData(data.toString()),
       ),
       onError: (error) => debugPrint('Chat error: ${error.toString()}'),


### PR DESCRIPTION
Entering chat-only mode requires navigating through a few layers of settings menus every time. This PR adds a new button in the chat menu that lets you quickly toggle chat-only mode (aka show/hide the video).