### PR TITLE
Add option to sync message delay with stream latency

### DIFF
--- a/lib/models/badges.g.dart
+++ b/lib/models/badges.g.dart
@@ -17,7 +17,7 @@ BadgeInfoTwitch _$BadgeInfoTwitchFromJson(Map<String, dynamic> json) =>
     );
 
 BadgeInfoFFZ _$BadgeInfoFFZFromJson(Map<String, dynamic> json) => BadgeInfoFFZ(
-      json['id'] as int,
+      (json['id'] as num).toInt(),
       json['title'] as String,
       json['color'] as String,
       BadgeUrlsFFZ.fromJson(json['urls'] as Map<String, dynamic>),

--- a/lib/models/chatters.g.dart
+++ b/lib/models/chatters.g.dart
@@ -7,7 +7,7 @@ part of 'chatters.dart';
 // **************************************************************************
 
 ChatUsers _$ChatUsersFromJson(Map<String, dynamic> json) => ChatUsers(
-      json['chatter_count'] as int,
+      (json['chatter_count'] as num).toInt(),
       Chatters.fromJson(json['chatters'] as Map<String, dynamic>),
     );
 

--- a/lib/models/emotes.g.dart
+++ b/lib/models/emotes.g.dart
@@ -29,7 +29,7 @@ EmoteBTTVChannel _$EmoteBTTVChannelFromJson(Map<String, dynamic> json) =>
     );
 
 RoomFFZ _$RoomFFZFromJson(Map<String, dynamic> json) => RoomFFZ(
-      json['set'] as int,
+      (json['set'] as num).toInt(),
       json['vip_badge'] == null
           ? null
           : ImagesFFZ.fromJson(json['vip_badge'] as Map<String, dynamic>),
@@ -51,8 +51,8 @@ OwnerFFZ _$OwnerFFZFromJson(Map<String, dynamic> json) => OwnerFFZ(
 
 EmoteFFZ _$EmoteFFZFromJson(Map<String, dynamic> json) => EmoteFFZ(
       json['name'] as String,
-      json['height'] as int,
-      json['width'] as int,
+      (json['height'] as num).toInt(),
+      (json['width'] as num).toInt(),
       OwnerFFZ.fromJson(json['owner'] as Map<String, dynamic>),
       ImagesFFZ.fromJson(json['urls'] as Map<String, dynamic>),
     );
@@ -73,7 +73,7 @@ Owner7TV _$Owner7TVFromJson(Map<String, dynamic> json) => Owner7TV(
 Emote7TVData _$Emote7TVDataFromJson(Map<String, dynamic> json) => Emote7TVData(
       json['id'] as String,
       json['name'] as String,
-      json['flags'] as int,
+      (json['flags'] as num).toInt(),
       json['owner'] == null
           ? null
           : Owner7TV.fromJson(json['owner'] as Map<String, dynamic>),
@@ -89,16 +89,16 @@ Emote7TVHost _$Emote7TVHostFromJson(Map<String, dynamic> json) => Emote7TVHost(
 
 Emote7TVFile _$Emote7TVFileFromJson(Map<String, dynamic> json) => Emote7TVFile(
       json['name'] as String,
-      json['width'] as int,
-      json['height'] as int,
+      (json['width'] as num).toInt(),
+      (json['height'] as num).toInt(),
       json['format'] as String,
     );
 
 Emote _$EmoteFromJson(Map<String, dynamic> json) => Emote(
       name: json['name'] as String,
       realName: json['realName'] as String?,
-      width: json['width'] as int?,
-      height: json['height'] as int?,
+      width: (json['width'] as num?)?.toInt(),
+      height: (json['height'] as num?)?.toInt(),
       zeroWidth: json['zeroWidth'] as bool,
       url: json['url'] as String,
       type: $enumDecode(_$EmoteTypeEnumMap, json['type']),

--- a/lib/models/events.g.dart
+++ b/lib/models/events.g.dart
@@ -7,8 +7,8 @@ part of 'events.dart';
 // **************************************************************************
 
 SevenTVEvent _$SevenTVEventFromJson(Map<String, dynamic> json) => SevenTVEvent(
-      op: json['op'] as int,
-      t: json['t'] as int?,
+      op: (json['op'] as num).toInt(),
+      t: (json['t'] as num?)?.toInt(),
       d: SevenTVEventData.fromJson(json['d'] as Map<String, dynamic>),
     );
 

--- a/lib/models/stream.g.dart
+++ b/lib/models/stream.g.dart
@@ -13,7 +13,7 @@ StreamTwitch _$StreamTwitchFromJson(Map<String, dynamic> json) => StreamTwitch(
       json['game_id'] as String,
       json['game_name'] as String,
       json['title'] as String,
-      json['viewer_count'] as int,
+      (json['viewer_count'] as num).toInt(),
       json['started_at'] as String,
       json['thumbnail_url'] as String,
     );

--- a/lib/screens/channel/chat/stores/chat_store.dart
+++ b/lib/screens/channel/chat/stores/chat_store.dart
@@ -181,13 +181,28 @@ abstract class ChatStoreBase with Store {
     messageBuffer
         .add(IRCMessage.createNotice(message: 'Connecting to chat...'));
 
+    if (settings.showVideo && settings.chatDelay > 0) {
+      messageBuffer.add(
+        IRCMessage.createNotice(
+          message:
+              'Waiting ${settings.chatDelay.toInt()} ${settings.chatDelay == 1.0 ? 'second' : 'seconds'} due to message delay setting...',
+        ),
+      );
+    }
+
     reactions.add(
-      autorun((_) {
-        if (settings.chatDelay > 0 && settings.showVideo) {
+      reaction((_) => settings.showVideo, (showVideo) {
+        if (showVideo && settings.chatDelay > 0) {
           messageBuffer.add(
             IRCMessage.createNotice(
               message:
                   'Waiting ${settings.chatDelay.toInt()} ${settings.chatDelay == 1.0 ? 'second' : 'seconds'} due to message delay setting...',
+            ),
+          );
+        } else {
+          messageBuffer.add(
+            IRCMessage.createNotice(
+              message: 'Removing message delay...',
             ),
           );
         }

--- a/lib/screens/channel/chat/widgets/chat_bottom_bar.dart
+++ b/lib/screens/channel/chat/widgets/chat_bottom_bar.dart
@@ -209,7 +209,7 @@ class ChatBottomBar extends StatelessWidget {
                                       : emoteMenuButton,
                               hintMaxLines: 1,
                               hintText: chatStore.auth.isLoggedIn
-                                  ? 'Send a ${chatStore.replyingToMessage != null ? 'reply' : 'message'} ${chatStore.settings.chatDelay == 0 ? '' : '(${chatStore.settings.chatDelay.toInt()}s delay)'}'
+                                  ? 'Send a ${chatStore.replyingToMessage != null ? 'reply' : 'message'} ${chatStore.settings.chatDelay == 0 || !chatStore.settings.showVideo ? '' : '(${chatStore.settings.chatDelay.toInt()}s delay)'}'
                                   : 'Log in to chat',
                             ),
                             controller: chatStore.textController,

--- a/lib/screens/channel/video/video_store.dart
+++ b/lib/screens/channel/video/video_store.dart
@@ -45,7 +45,17 @@ abstract class VideoStoreBase with Store {
         ..addJavaScriptChannel(
           'Latency',
           onMessageReceived: (message) {
-            _latency = message.message;
+            final receivedLatency = message.message;
+            _latency = receivedLatency;
+
+            if (!settingsStore.autoSyncChatDelay) return;
+
+            final trimmedLatency = receivedLatency.split(' ')[0];
+            final latencyAsDouble = double.tryParse(trimmedLatency);
+
+            if (latencyAsDouble != null) {
+              settingsStore.chatDelay = latencyAsDouble;
+            }
           },
         )
         ..addJavaScriptChannel(

--- a/lib/screens/settings/chat_settings.dart
+++ b/lib/screens/settings/chat_settings.dart
@@ -170,17 +170,23 @@ class _ChatSettingsState extends State<ChatSettings> {
             onChanged: (newValue) => settingsStore.timestampType =
                 TimestampType.values[timestampNames.indexOf(newValue)],
           ),
-          const SectionHeader('Delay', showDivider: true),
-          SettingsListSlider(
-            title: 'Message delay',
-            trailing: '${settingsStore.chatDelay.toInt()}s',
-            subtitle:
-                'Adds a delay (in seconds) before each message is rendered in chat. ${Platform.isIOS ? '15 seconds is recommended for iOS.' : ''}',
-            value: settingsStore.chatDelay,
-            max: 30.0,
-            divisions: 30,
-            onChanged: (newValue) => settingsStore.chatDelay = newValue,
+          const SectionHeader('Delay and Latency', showDivider: true),
+          SettingsListSwitch(
+            title: 'Sync message delay with stream latency',
+            value: settingsStore.autoSyncChatDelay,
+            onChanged: (newValue) => settingsStore.autoSyncChatDelay = newValue,
           ),
+          if (!settingsStore.autoSyncChatDelay)
+            SettingsListSlider(
+              title: 'Message delay',
+              trailing: '${settingsStore.chatDelay.toInt()} seconds',
+              subtitle:
+                  'Adds a delay before each message is rendered in chat. ${Platform.isIOS ? '15 seconds is recommended for iOS.' : ''}',
+              value: settingsStore.chatDelay,
+              max: 30.0,
+              divisions: 30,
+              onChanged: (newValue) => settingsStore.chatDelay = newValue,
+            ),
           const SectionHeader('Alerts', showDivider: true),
           SettingsListSwitch(
             title: 'Highlight first time chatters',

--- a/lib/screens/settings/chat_settings.dart
+++ b/lib/screens/settings/chat_settings.dart
@@ -170,7 +170,7 @@ class _ChatSettingsState extends State<ChatSettings> {
             onChanged: (newValue) => settingsStore.timestampType =
                 TimestampType.values[timestampNames.indexOf(newValue)],
           ),
-          const SectionHeader('Delay and Latency', showDivider: true),
+          const SectionHeader('Delay and latency', showDivider: true),
           SettingsListSwitch(
             title: 'Sync message delay with stream latency (experimental)',
             value: settingsStore.autoSyncChatDelay,

--- a/lib/screens/settings/chat_settings.dart
+++ b/lib/screens/settings/chat_settings.dart
@@ -172,7 +172,7 @@ class _ChatSettingsState extends State<ChatSettings> {
           ),
           const SectionHeader('Delay and Latency', showDivider: true),
           SettingsListSwitch(
-            title: 'Sync message delay with stream latency',
+            title: 'Sync message delay with stream latency (experimental)',
             value: settingsStore.autoSyncChatDelay,
             onChanged: (newValue) => settingsStore.autoSyncChatDelay = newValue,
           ),

--- a/lib/screens/settings/stores/settings_store.dart
+++ b/lib/screens/settings/stores/settings_store.dart
@@ -116,6 +116,7 @@ abstract class _SettingsStoreBase with Store {
   static const defaultTimestampType = TimestampType.disabled;
 
   // Delay defaults
+  static const defaultAutoSyncChatDelay = false;
   static const defaultChatDelay = 0.0;
 
   // Alert defaults
@@ -182,6 +183,10 @@ abstract class _SettingsStoreBase with Store {
   var timestampType = defaultTimestampType;
 
   // Delay options
+  @JsonKey(defaultValue: defaultAutoSyncChatDelay)
+  @observable
+  var autoSyncChatDelay = defaultAutoSyncChatDelay;
+
   @JsonKey(defaultValue: defaultChatDelay)
   @observable
   var chatDelay = defaultChatDelay;
@@ -252,6 +257,7 @@ abstract class _SettingsStoreBase with Store {
     showChatMessageDividers = defaultShowChatMessageDividers;
     timestampType = defaultTimestampType;
 
+    autoSyncChatDelay = defaultAutoSyncChatDelay;
     chatDelay = defaultChatDelay;
 
     highlightFirstTimeChatter = defaultHighlightFirstTimeChatter;

--- a/lib/screens/settings/stores/settings_store.g.dart
+++ b/lib/screens/settings/stores/settings_store.g.dart
@@ -34,6 +34,7 @@ SettingsStore _$SettingsStoreFromJson(Map<String, dynamic> json) =>
               _$TimestampTypeEnumMap, json['timestampType'],
               unknownValue: TimestampType.disabled) ??
           TimestampType.disabled
+      ..autoSyncChatDelay = json['autoSyncChatDelay'] as bool? ?? false
       ..chatDelay = (json['chatDelay'] as num?)?.toDouble() ?? 0.0
       ..highlightFirstTimeChatter =
           json['highlightFirstTimeChatter'] as bool? ?? true
@@ -79,6 +80,7 @@ Map<String, dynamic> _$SettingsStoreToJson(SettingsStore instance) =>
       'showDeletedMessages': instance.showDeletedMessages,
       'showChatMessageDividers': instance.showChatMessageDividers,
       'timestampType': _$TimestampTypeEnumMap[instance.timestampType]!,
+      'autoSyncChatDelay': instance.autoSyncChatDelay,
       'chatDelay': instance.chatDelay,
       'highlightFirstTimeChatter': instance.highlightFirstTimeChatter,
       'showUserNotices': instance.showUserNotices,
@@ -428,6 +430,22 @@ mixin _$SettingsStore on _SettingsStoreBase, Store {
   set timestampType(TimestampType value) {
     _$timestampTypeAtom.reportWrite(value, super.timestampType, () {
       super.timestampType = value;
+    });
+  }
+
+  late final _$autoSyncChatDelayAtom =
+      Atom(name: '_SettingsStoreBase.autoSyncChatDelay', context: context);
+
+  @override
+  bool get autoSyncChatDelay {
+    _$autoSyncChatDelayAtom.reportRead();
+    return super.autoSyncChatDelay;
+  }
+
+  @override
+  set autoSyncChatDelay(bool value) {
+    _$autoSyncChatDelayAtom.reportWrite(value, super.autoSyncChatDelay, () {
+      super.autoSyncChatDelay = value;
     });
   }
 
@@ -788,6 +806,7 @@ useReadableColors: ${useReadableColors},
 showDeletedMessages: ${showDeletedMessages},
 showChatMessageDividers: ${showChatMessageDividers},
 timestampType: ${timestampType},
+autoSyncChatDelay: ${autoSyncChatDelay},
 chatDelay: ${chatDelay},
 highlightFirstTimeChatter: ${highlightFirstTimeChatter},
 showUserNotices: ${showUserNotices},


### PR DESCRIPTION
The stream latency will sometimes gradually increase due to connection or player issues. This causes the stream to further become out of sync with the chat despite setting a message delay setting. 

This PR adds a new setting toggle that makes the chat latency be in sync with the stream latency. There might be some unintended side effects so it's labeled experimental.