### PR TITLE
Add photo view for thumbnails, emotes, and badges

### DIFF
--- a/lib/models/irc.dart
+++ b/lib/models/irc.dart
@@ -10,6 +10,7 @@ import 'package:frosty/screens/channel/chat/stores/chat_assets_store.dart';
 import 'package:frosty/screens/settings/stores/settings_store.dart';
 import 'package:frosty/utils.dart';
 import 'package:frosty/widgets/cached_image.dart';
+import 'package:frosty/widgets/photo_view.dart';
 import 'package:intl/intl.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -695,7 +696,13 @@ class IRCMessage {
         primary: false,
         children: [
           ListTile(
-            leading: leading,
+            leading: InkWell(
+              onTap: () => showDialog(
+                context: context,
+                builder: (context) => FrostyPhotoViewDialog(imageUrl: url),
+              ),
+              child: leading,
+            ),
             title: Text(
               title,
               style: const TextStyle(

--- a/lib/screens/home/stream_list/stream_card.dart
+++ b/lib/screens/home/stream_list/stream_card.dart
@@ -10,6 +10,7 @@ import 'package:frosty/utils.dart';
 import 'package:frosty/widgets/block_report_modal.dart';
 import 'package:frosty/widgets/cached_image.dart';
 import 'package:frosty/widgets/loading_indicator.dart';
+import 'package:frosty/widgets/photo_view.dart';
 import 'package:frosty/widgets/profile_picture.dart';
 import 'package:frosty/widgets/uptime.dart';
 import 'package:intl/intl.dart';
@@ -72,7 +73,19 @@ class StreamCard extends StatelessWidget {
       child: Stack(
         alignment: AlignmentDirectional.bottomEnd,
         children: [
-          thumbnail,
+          GestureDetector(
+            onLongPress: () => showDialog(
+              context: context,
+              builder: (context) => FrostyPhotoViewDialog(
+                imageUrl: streamInfo.thumbnailUrl.replaceFirst(
+                      '-{width}x{height}',
+                      '',
+                    ) +
+                    cacheUrlExtension,
+              ),
+            ),
+            child: thumbnail,
+          ),
           Container(
             padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
             decoration: const BoxDecoration(

--- a/lib/widgets/photo_view.dart
+++ b/lib/widgets/photo_view.dart
@@ -11,23 +11,15 @@ class FrostyPhotoViewDialog extends StatelessWidget {
     return Stack(
       alignment: Alignment.bottomCenter,
       children: [
-        Dismissible(
-          key: const Key('photo_view_dismissible'),
-          direction: DismissDirection.vertical,
-          onDismissed: Navigator.of(context).pop,
-          child: PhotoView(
-            imageProvider: NetworkImage(imageUrl),
-            backgroundDecoration:
-                const BoxDecoration(color: Colors.transparent),
-          ),
+        PhotoView(
+          imageProvider: NetworkImage(imageUrl),
+          backgroundDecoration: const BoxDecoration(color: Colors.transparent),
         ),
-        const Padding(
-          padding: EdgeInsets.only(bottom: 48),
-          child: Text(
-            'Swipe up or down to dismiss',
-            style: TextStyle(
-              color: Colors.white,
-            ),
+        Padding(
+          padding: const EdgeInsets.only(bottom: 32),
+          child: IconButton(
+            icon: const Icon(Icons.close, color: Colors.white),
+            onPressed: Navigator.of(context).pop,
           ),
         ),
       ],

--- a/lib/widgets/photo_view.dart
+++ b/lib/widgets/photo_view.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:photo_view/photo_view.dart';
 
@@ -12,7 +13,7 @@ class FrostyPhotoViewDialog extends StatelessWidget {
       alignment: Alignment.bottomCenter,
       children: [
         PhotoView(
-          imageProvider: NetworkImage(imageUrl),
+          imageProvider: CachedNetworkImageProvider(imageUrl),
           backgroundDecoration: const BoxDecoration(color: Colors.transparent),
         ),
         Padding(

--- a/lib/widgets/photo_view.dart
+++ b/lib/widgets/photo_view.dart
@@ -2,26 +2,40 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:photo_view/photo_view.dart';
 
-class FrostyPhotoViewDialog extends StatelessWidget {
+class FrostyPhotoViewDialog extends StatefulWidget {
   final String imageUrl;
 
   const FrostyPhotoViewDialog({super.key, required this.imageUrl});
 
   @override
+  State<FrostyPhotoViewDialog> createState() => _FrostyPhotoViewDialogState();
+}
+
+class _FrostyPhotoViewDialogState extends State<FrostyPhotoViewDialog> {
+  PhotoViewScaleState photoViewScaleState = PhotoViewScaleState.initial;
+
+  @override
   Widget build(BuildContext context) {
     return Stack(
-      alignment: Alignment.bottomCenter,
+      alignment: Alignment.topCenter,
       children: [
-        PhotoView(
-          imageProvider: CachedNetworkImageProvider(imageUrl),
-          backgroundDecoration: const BoxDecoration(color: Colors.transparent),
-        ),
-        Padding(
-          padding: const EdgeInsets.only(bottom: 32),
-          child: IconButton(
-            icon: const Icon(Icons.close, color: Colors.white),
-            onPressed: Navigator.of(context).pop,
+        Dismissible(
+          key: const Key('photo_view_dismissible'),
+          direction: photoViewScaleState == PhotoViewScaleState.initial
+              ? DismissDirection.vertical
+              : DismissDirection.none,
+          onDismissed: Navigator.of(context).pop,
+          child: PhotoView(
+            imageProvider: CachedNetworkImageProvider(widget.imageUrl),
+            scaleStateChangedCallback: (value) =>
+                setState(() => photoViewScaleState = value),
+            backgroundDecoration:
+                const BoxDecoration(color: Colors.transparent),
           ),
+        ),
+        IconButton(
+          icon: const Icon(Icons.close, color: Colors.white),
+          onPressed: Navigator.of(context).pop,
         ),
       ],
     );

--- a/lib/widgets/photo_view.dart
+++ b/lib/widgets/photo_view.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:photo_view/photo_view.dart';
+
+class FrostyPhotoViewDialog extends StatelessWidget {
+  final String imageUrl;
+
+  const FrostyPhotoViewDialog({super.key, required this.imageUrl});
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      alignment: Alignment.bottomCenter,
+      children: [
+        Dismissible(
+          key: const Key('photo_view_dismissible'),
+          direction: DismissDirection.vertical,
+          onDismissed: Navigator.of(context).pop,
+          child: PhotoView(
+            imageProvider: NetworkImage(imageUrl),
+            backgroundDecoration:
+                const BoxDecoration(color: Colors.transparent),
+          ),
+        ),
+        const Padding(
+          padding: EdgeInsets.only(bottom: 48),
+          child: Text(
+            'Swipe up or down to dismiss',
+            style: TextStyle(
+              color: Colors.white,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -837,6 +837,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.2"
+  photo_view:
+    dependency: "direct main"
+    description:
+      name: photo_view
+      sha256: "1fc3d970a91295fbd1364296575f854c9863f225505c28c46e0a03e48960c75e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.0"
   platform:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -64,6 +64,7 @@ dependencies:
   advanced_in_app_review: ^1.1.3
   webview_flutter_android: ^3.7.0
   webview_flutter_wkwebview: ^3.4.3
+  photo_view: ^0.15.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR adds the ability to long-press on a stream card thumbnail or tap an emote or badge in the details bottom sheet to show a full-screen zoomable photo view.