### PR TITLE
Add option to enable historical recent messages in chat

### DIFF
--- a/lib/apis/twitch_api.dart
+++ b/lib/apis/twitch_api.dart
@@ -522,4 +522,20 @@ class TwitchApi {
       return false;
     }
   }
+
+  // Unblocks the user with the given ID and returns true on success or false on failure.
+  Future<List<dynamic>> getRecentMessages({
+    required String userLogin,
+  }) async {
+    final url = Uri.parse(
+      'https://recent-messages.robotty.de/api/v2/recent-messages/$userLogin',
+    );
+
+    final response = await _client.get(url);
+    if (response.statusCode == 200) {
+      return jsonDecode(response.body)['messages'] as List;
+    } else {
+      return Future.error('Failed to get recent messages for $userLogin');
+    }
+  }
 }

--- a/lib/models/irc.dart
+++ b/lib/models/irc.dart
@@ -808,8 +808,6 @@ class IRCMessage {
       }
     }
 
-    splitMessage.length > 3 ? splitMessage.sublist(3).join(' ') : null;
-
     // Now process any Twitch emotes contained in the message tags.
     // The map containing emotes from the user's tags to their URL.
     // This may include sub emotes that they can access but other users cannot.

--- a/lib/models/irc.dart
+++ b/lib/models/irc.dart
@@ -797,13 +797,18 @@ class IRCMessage {
         : splitMessage[0].substring(0, splitMessage[0].indexOf('!'));
 
     // If there is an associated message, set it.
-    //
-    // Also remove any "INVALID/UNDEFINED" Unicode characters.
-    // Rendering this character on iOS shows a question mark inside a square.
-    // This character is used by some clients to bypass restrictions on repeating message.
-    var message = splitMessage.length > 3
-        ? splitMessage.sublist(3).join(' ').substring(1)
-        : null;
+    String? message;
+    if (splitMessage.length > 3) {
+      final combinedMessage = splitMessage.sublist(3).join(' ');
+
+      if (combinedMessage.startsWith(':')) {
+        message = combinedMessage.substring(1);
+      } else {
+        message = combinedMessage;
+      }
+    }
+
+    splitMessage.length > 3 ? splitMessage.sublist(3).join(' ') : null;
 
     // Now process any Twitch emotes contained in the message tags.
     // The map containing emotes from the user's tags to their URL.
@@ -811,7 +816,7 @@ class IRCMessage {
     final localEmotes = <String, Emote>{};
 
     final emoteTags = mappedTags['emotes'];
-    if (emoteTags != null) {
+    if (emoteTags != null && message != null) {
       // Emotes and their indices are separated by '/' so split them there.
       final emotes = emoteTags.split('/');
 
@@ -838,7 +843,7 @@ class IRCMessage {
         final startIndex = int.parse(indexSplit[0]);
         final endIndex = int.parse(indexSplit[1]);
 
-        final emoteWord = message!.substring(startIndex, endIndex + 1);
+        final emoteWord = message.substring(startIndex, endIndex + 1);
 
         // Store the emote word and its associated URL for later use.
         localEmotes[emoteWord] = Emote(
@@ -869,6 +874,9 @@ class IRCMessage {
       // Escape the message
       message = message
           .split(' ')
+          // Also remove any "INVALID/UNDEFINED" Unicode characters.
+          // Rendering this character on iOS shows a question mark inside a square.
+          // This character is used by some clients to bypass restrictions on repeating message.
           .map((word) => word.replaceAll('\u{E0000}', '').trim())
           .where((element) => element != '')
           .join(' ');

--- a/lib/screens/channel/channel.dart
+++ b/lib/screens/channel/channel.dart
@@ -47,6 +47,7 @@ class _VideoChatState extends State<VideoChat> {
   final _chatKey = GlobalKey();
 
   late final ChatStore _chatStore = ChatStore(
+    twitchApi: context.read<TwitchApi>(),
     channelName: widget.userLogin,
     channelId: widget.userId,
     displayName: widget.userName,

--- a/lib/screens/channel/chat/stores/chat_store.dart
+++ b/lib/screens/channel/chat/stores/chat_store.dart
@@ -540,7 +540,7 @@ abstract class ChatStoreBase with Store {
         }
 
         if (_retries >= _maxRetries) {
-          _messages.add(
+          messageBuffer.add(
             IRCMessage.createNotice(
               message: 'Disconnected from chat',
             ),
@@ -552,7 +552,7 @@ abstract class ChatStoreBase with Store {
           // Add notice that chat was disconnected and then wait the backoff time before reconnecting.
           final notice =
               'Disconnected from chat, waiting $_backoffTime ${_backoffTime == 1 ? 'second' : 'seconds'} before reconnecting...';
-          _messages.add(IRCMessage.createNotice(message: notice));
+          messageBuffer.add(IRCMessage.createNotice(message: notice));
         }
 
         await Future.delayed(Duration(seconds: _backoffTime));
@@ -562,7 +562,7 @@ abstract class ChatStoreBase with Store {
 
         // Increment the retry count and attempt the reconnect.
         _retries++;
-        _messages.add(
+        messageBuffer.add(
           IRCMessage.createNotice(
             message: 'Reconnecting to chat (attempt $_retries)...',
           ),

--- a/lib/screens/channel/chat/stores/chat_store.dart
+++ b/lib/screens/channel/chat/stores/chat_store.dart
@@ -202,12 +202,6 @@ abstract class ChatStoreBase with Store {
       ),
     );
 
-    // Create a timer that will add messages from the buffer every 200 milliseconds.
-    _messageBufferTimer = Timer.periodic(
-      const Duration(milliseconds: 200),
-      (timer) => addMessages(),
-    );
-
     assetsStore.init();
 
     _messages.add(IRCMessage.createNotice(message: 'Connecting to chat...'));
@@ -385,6 +379,13 @@ abstract class ChatStoreBase with Store {
             message:
                 "Welcome to ${getReadableName(displayName, channelName)}'s chat!",
           ),
+        );
+
+        // Activate the message buffer.
+        // Create a timer that will add messages from the buffer every 200 milliseconds.
+        _messageBufferTimer = Timer.periodic(
+          const Duration(milliseconds: 200),
+          (timer) => addMessages(),
         );
 
         getAssets().then((_) {

--- a/lib/screens/channel/chat/stores/chat_store.g.dart
+++ b/lib/screens/channel/chat/stores/chat_store.g.dart
@@ -219,6 +219,14 @@ mixin _$ChatStore on ChatStoreBase, Store {
     return _$getAssetsAsyncAction.run(() => super.getAssets());
   }
 
+  late final _$getRecentMessageAsyncAction =
+      AsyncAction('ChatStoreBase.getRecentMessage', context: context);
+
+  @override
+  Future<void> getRecentMessage() {
+    return _$getRecentMessageAsyncAction.run(() => super.getRecentMessage());
+  }
+
   late final _$ChatStoreBaseActionController =
       ActionController(name: 'ChatStoreBase', context: context);
 

--- a/lib/screens/channel/chat/widgets/chat_message.dart
+++ b/lib/screens/channel/chat/widgets/chat_message.dart
@@ -440,15 +440,20 @@ class ChatMessage extends StatelessWidget {
                 child: dividedMessage,
               );
 
-        return InkWell(
-          onTap: () {
-            FocusScope.of(context).unfocus();
-            if (chatStore.assetsStore.showEmoteMenu) {
-              chatStore.assetsStore.showEmoteMenu = false;
-            }
-          },
-          onLongPress: () => onLongPressMessage(context, defaultTextStyle),
-          child: coloredMessage,
+        final isHistorical = ircMessage.tags['historical'] == '1';
+
+        return Opacity(
+          opacity: isHistorical ? 0.5 : 1,
+          child: InkWell(
+            onTap: () {
+              FocusScope.of(context).unfocus();
+              if (chatStore.assetsStore.showEmoteMenu) {
+                chatStore.assetsStore.showEmoteMenu = false;
+              }
+            },
+            onLongPress: () => onLongPressMessage(context, defaultTextStyle),
+            child: coloredMessage,
+          ),
         );
       },
     );

--- a/lib/screens/onboarding/onboarding_setup.dart
+++ b/lib/screens/onboarding/onboarding_setup.dart
@@ -35,11 +35,11 @@ class OnboardingSetup extends StatelessWidget {
                     ThemeType.values[themeNames.indexOf(newTheme)],
               ),
               SettingsListSwitch(
-                title: 'Show recent messages',
+                title: 'Show historical recent messages',
                 subtitle: Text.rich(
                   TextSpan(
                     text:
-                        'Loads recent messages when connecting to chat. Messages are loaded from a third-party API service at ',
+                        'Loads historical recent messages in chat through a third-party API service at ',
                     children: [
                       TextSpan(
                         text: 'https://recent-messages.robotty.de/',

--- a/lib/screens/onboarding/onboarding_setup.dart
+++ b/lib/screens/onboarding/onboarding_setup.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:firebase_performance/firebase_performance.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:frosty/screens/onboarding/onboarding_scaffold.dart';
@@ -9,6 +10,7 @@ import 'package:frosty/screens/settings/stores/settings_store.dart';
 import 'package:frosty/screens/settings/widgets/settings_list_select.dart';
 import 'package:frosty/screens/settings/widgets/settings_list_switch.dart';
 import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class OnboardingSetup extends StatelessWidget {
   const OnboardingSetup({super.key});
@@ -31,6 +33,37 @@ class OnboardingSetup extends StatelessWidget {
                 options: themeNames,
                 onChanged: (newTheme) => settingsStore.themeType =
                     ThemeType.values[themeNames.indexOf(newTheme)],
+              ),
+              SettingsListSwitch(
+                title: 'Show recent messages',
+                subtitle: Text.rich(
+                  TextSpan(
+                    text:
+                        'Loads recent messages when connecting to chat. Messages are loaded from a third-party API service at ',
+                    children: [
+                      TextSpan(
+                        text: 'https://recent-messages.robotty.de/',
+                        style: const TextStyle(
+                          color: Colors.blue,
+                          decoration: TextDecoration.underline,
+                          decorationColor: Colors.blue,
+                        ),
+                        recognizer: TapGestureRecognizer()
+                          ..onTap = () => launchUrl(
+                                Uri.parse(
+                                  'https://recent-messages.robotty.de/',
+                                ),
+                                mode: settingsStore.launchUrlExternal
+                                    ? LaunchMode.externalApplication
+                                    : LaunchMode.inAppWebView,
+                              ),
+                      ),
+                    ],
+                  ),
+                ),
+                value: settingsStore.showRecentMessages,
+                onChanged: (newValue) =>
+                    settingsStore.showRecentMessages = newValue,
               ),
               SettingsListSwitch(
                 title: 'Share crash logs and analytics',

--- a/lib/screens/settings/chat_settings.dart
+++ b/lib/screens/settings/chat_settings.dart
@@ -328,11 +328,11 @@ class _ChatSettingsState extends State<ChatSettings> {
           ),
           const SectionHeader('Recent messages', showDivider: true),
           SettingsListSwitch(
-            title: 'Show recent messages',
+            title: 'Show historical recent messages',
             subtitle: Text.rich(
               TextSpan(
                 text:
-                    'Loads recent messages when connecting to chat. Messages are loaded from a third-party API service at ',
+                    'Loads historical recent messages in chat through a third-party API service at ',
                 children: [
                   TextSpan(
                     text: 'https://recent-messages.robotty.de/',

--- a/lib/screens/settings/chat_settings.dart
+++ b/lib/screens/settings/chat_settings.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:frosty/constants.dart';
@@ -9,6 +10,7 @@ import 'package:frosty/screens/settings/widgets/settings_list_slider.dart';
 import 'package:frosty/screens/settings/widgets/settings_list_switch.dart';
 import 'package:frosty/widgets/cached_image.dart';
 import 'package:frosty/widgets/section_header.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class ChatSettings extends StatefulWidget {
   final SettingsStore settingsStore;
@@ -327,8 +329,30 @@ class _ChatSettingsState extends State<ChatSettings> {
           const SectionHeader('Recent messages', showDivider: true),
           SettingsListSwitch(
             title: 'Show recent messages',
-            subtitle: const Text(
-              'Show recent messages when connecting to chat. Third-party service from https://recent-messages.robotty.de/',
+            subtitle: Text.rich(
+              TextSpan(
+                text:
+                    'Loads recent messages when connecting to chat. Messages are loaded from a third-party API service at ',
+                children: [
+                  TextSpan(
+                    text: 'https://recent-messages.robotty.de/',
+                    style: const TextStyle(
+                      color: Colors.blue,
+                      decoration: TextDecoration.underline,
+                      decorationColor: Colors.blue,
+                    ),
+                    recognizer: TapGestureRecognizer()
+                      ..onTap = () => launchUrl(
+                            Uri.parse(
+                              'https://recent-messages.robotty.de/',
+                            ),
+                            mode: settingsStore.launchUrlExternal
+                                ? LaunchMode.externalApplication
+                                : LaunchMode.inAppWebView,
+                          ),
+                  ),
+                ],
+              ),
             ),
             value: settingsStore.showRecentMessages,
             onChanged: (newValue) =>

--- a/lib/screens/settings/chat_settings.dart
+++ b/lib/screens/settings/chat_settings.dart
@@ -324,6 +324,16 @@ class _ChatSettingsState extends State<ChatSettings> {
             value: settingsStore.showFFZBadges,
             onChanged: (newValue) => settingsStore.showFFZBadges = newValue,
           ),
+          const SectionHeader('Recent messages', showDivider: true),
+          SettingsListSwitch(
+            title: 'Show recent messages',
+            subtitle: const Text(
+              'Show recent messages when connecting to chat. Third-party service from https://recent-messages.robotty.de/',
+            ),
+            value: settingsStore.showRecentMessages,
+            onChanged: (newValue) =>
+                settingsStore.showRecentMessages = newValue,
+          ),
         ],
       ),
     );

--- a/lib/screens/settings/stores/settings_store.dart
+++ b/lib/screens/settings/stores/settings_store.dart
@@ -150,6 +150,9 @@ abstract class _SettingsStoreBase with Store {
   static const defaultShowFFZEmotes = true;
   static const defaultShowFFZBadges = true;
 
+  // Recent messages defaults
+  static const defaultShowRecentMessages = false;
+
   // Message sizing options
   @JsonKey(defaultValue: defaultBadgeScale)
   @observable
@@ -282,6 +285,11 @@ abstract class _SettingsStoreBase with Store {
   @observable
   var showFFZBadges = defaultShowFFZBadges;
 
+  // Recent messages
+  @JsonKey(defaultValue: defaultShowRecentMessages)
+  @observable
+  var showRecentMessages = defaultShowRecentMessages;
+
   @action
   void resetChatSettings() {
     badgeScale = defaultBadgeScale;
@@ -321,6 +329,8 @@ abstract class _SettingsStoreBase with Store {
     showBTTVBadges = defaultShowBTTVBadges;
     showFFZEmotes = defaultShowFFZEmotes;
     showFFZBadges = defaultShowFFZBadges;
+
+    showRecentMessages = defaultShowRecentMessages;
   }
 
   // * Other settings

--- a/lib/screens/settings/stores/settings_store.g.dart
+++ b/lib/screens/settings/stores/settings_store.g.dart
@@ -61,6 +61,7 @@ SettingsStore _$SettingsStoreFromJson(Map<String, dynamic> json) =>
       ..showBTTVBadges = json['showBTTVBadges'] as bool? ?? true
       ..showFFZEmotes = json['showFFZEmotes'] as bool? ?? true
       ..showFFZBadges = json['showFFZBadges'] as bool? ?? true
+      ..showRecentMessages = json['showRecentMessages'] as bool? ?? false
       ..shareCrashLogsAndAnalytics =
           json['shareCrashLogsAndAnalytics'] as bool? ?? true
       ..fullScreen = json['fullScreen'] as bool? ?? false
@@ -109,6 +110,7 @@ Map<String, dynamic> _$SettingsStoreToJson(SettingsStore instance) =>
       'showBTTVBadges': instance.showBTTVBadges,
       'showFFZEmotes': instance.showFFZEmotes,
       'showFFZBadges': instance.showFFZBadges,
+      'showRecentMessages': instance.showRecentMessages,
       'shareCrashLogsAndAnalytics': instance.shareCrashLogsAndAnalytics,
       'fullScreen': instance.fullScreen,
       'fullScreenChatOverlay': instance.fullScreenChatOverlay,
@@ -791,6 +793,22 @@ mixin _$SettingsStore on _SettingsStoreBase, Store {
     });
   }
 
+  late final _$showRecentMessagesAtom =
+      Atom(name: '_SettingsStoreBase.showRecentMessages', context: context);
+
+  @override
+  bool get showRecentMessages {
+    _$showRecentMessagesAtom.reportRead();
+    return super.showRecentMessages;
+  }
+
+  @override
+  set showRecentMessages(bool value) {
+    _$showRecentMessagesAtom.reportWrite(value, super.showRecentMessages, () {
+      super.showRecentMessages = value;
+    });
+  }
+
   late final _$shareCrashLogsAndAnalyticsAtom = Atom(
       name: '_SettingsStoreBase.shareCrashLogsAndAnalytics', context: context);
 
@@ -953,6 +971,7 @@ showBTTVEmotes: ${showBTTVEmotes},
 showBTTVBadges: ${showBTTVBadges},
 showFFZEmotes: ${showFFZEmotes},
 showFFZBadges: ${showFFZBadges},
+showRecentMessages: ${showRecentMessages},
 shareCrashLogsAndAnalytics: ${shareCrashLogsAndAnalytics},
 fullScreen: ${fullScreen},
 fullScreenChatOverlay: ${fullScreenChatOverlay}


### PR DESCRIPTION
This PR adds an option that uses the [recent messages API](https://recent-messages.robotty.de/api) to fill in historical messages when connecting to chat. The historical messages will have 50% opacity to distinguish them in chat. Off by default to be opt-in.

Closes #358.