### PR TITLE
Add release notes on launch

### DIFF
--- a/assets/release-notes.md
+++ b/assets/release-notes.md
@@ -1,0 +1,19 @@
+# v4.3.0
+
+August 12, 2024
+
+## New Features
+
+- Added the ability to tap on user mentions in chat by @Artiu in https://github.com/tommyxchow/frosty/pull/314
+- Added stream latency details to the custom overlay in landscape mode by @Artiu in https://github.com/tommyxchow/frosty/pull/313
+
+## Improvements
+
+- Improved how the default Twitch overlay is hidden when the custom overlay is enabled by @Artiu in https://github.com/tommyxchow/frosty/pull/313
+- Links in chat are now also underlined
+
+## Bug Fixes
+
+- Fixed 7TV emote set updates not respecting the chat delay setting
+
+### See all release notes at https://github.com/tommyxchow/frosty/releases

--- a/assets/release-notes.md
+++ b/assets/release-notes.md
@@ -1,19 +1,10 @@
-# v4.3.0
+## v4.3.1
 
-August 12, 2024
+April 21, 2024
 
-## New Features
+### Bug Fixes
+* [Android] Fixed stream quality options not showing by @Shingyx in https://github.com/tommyxchow/frosty/pull/340
+* Fixed stream latency not showing by @Shingyx in https://github.com/tommyxchow/frosty/pull/340
+* Fixed stream latency icon color on light mode
 
-- Added the ability to tap on user mentions in chat by @Artiu in https://github.com/tommyxchow/frosty/pull/314
-- Added stream latency details to the custom overlay in landscape mode by @Artiu in https://github.com/tommyxchow/frosty/pull/313
-
-## Improvements
-
-- Improved how the default Twitch overlay is hidden when the custom overlay is enabled by @Artiu in https://github.com/tommyxchow/frosty/pull/313
-- Links in chat are now also underlined
-
-## Bug Fixes
-
-- Fixed 7TV emote set updates not respecting the chat delay setting
-
-### See all release notes at https://github.com/tommyxchow/frosty/releases
+#### See all release notes at https://github.com/tommyxchow/frosty/releases

--- a/lib/screens/home/home.dart
+++ b/lib/screens/home/home.dart
@@ -9,8 +9,11 @@ import 'package:frosty/screens/home/top/top.dart';
 import 'package:frosty/screens/settings/settings.dart';
 import 'package:frosty/screens/settings/stores/auth_store.dart';
 import 'package:frosty/screens/settings/stores/settings_store.dart';
+import 'package:frosty/screens/settings/widgets/release_notes.dart';
 import 'package:frosty/widgets/profile_picture.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class Home extends StatefulWidget {
   const Home({super.key});
@@ -23,6 +26,31 @@ class _HomeState extends State<Home> {
   late final _authStore = context.read<AuthStore>();
 
   late final _homeStore = HomeStore(authStore: _authStore);
+
+  Future<void> checkAndShowReleaseNotes() async {
+    final packageInfo = await PackageInfo.fromPlatform();
+    final prefs = await SharedPreferences.getInstance();
+
+    final currentVersion = packageInfo.version;
+    final storedVersion = prefs.getString('last_shown_version');
+
+    if (storedVersion == null || storedVersion != currentVersion) {
+      if (!mounted) return;
+
+      Navigator.push(
+        context,
+        MaterialPageRoute(builder: (context) => const ReleaseNotes()),
+      );
+
+      await prefs.setString('last_shown_version', currentVersion);
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    checkAndShowReleaseNotes();
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/settings/other_settings.dart
+++ b/lib/screens/settings/other_settings.dart
@@ -7,6 +7,7 @@ import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:frosty/screens/settings/stores/settings_store.dart';
+import 'package:frosty/screens/settings/widgets/release_notes.dart';
 import 'package:frosty/screens/settings/widgets/settings_list_switch.dart';
 import 'package:frosty/widgets/alert_message.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -86,13 +87,12 @@ class _OtherSettingsState extends State<OtherSettings> {
           },
         ),
         ListTile(
-          leading: const Icon(Icons.launch_rounded),
-          title: const Text('Changelog'),
-          onTap: () => launchUrl(
-            Uri.parse('https://github.com/tommyxchow/frosty/releases'),
-            mode: widget.settingsStore.launchUrlExternal
-                ? LaunchMode.externalApplication
-                : LaunchMode.inAppBrowserView,
+          leading: const Icon(Icons.notes_rounded),
+          title: const Text('Release notes'),
+          onTap: () => Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (context) => const ReleaseNotes(),
+            ),
           ),
         ),
         ListTile(

--- a/lib/screens/settings/widgets/release_notes.dart
+++ b/lib/screens/settings/widgets/release_notes.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:frosty/screens/settings/stores/settings_store.dart';
+import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher_string.dart';
+
+class ReleaseNotes extends StatefulWidget {
+  const ReleaseNotes({super.key});
+
+  @override
+  State<ReleaseNotes> createState() => _ReleaseNotesState();
+}
+
+class _ReleaseNotesState extends State<ReleaseNotes> {
+  String releaseNotes = '';
+
+  @override
+  void initState() {
+    super.initState();
+
+    rootBundle.loadString('assets/release-notes.md').then(
+      (changelog) {
+        setState(() {
+          releaseNotes = changelog;
+        });
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Release notes'),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: Markdown(
+              data: releaseNotes,
+              styleSheet: MarkdownStyleSheet(
+                h1: const TextStyle(fontSize: 24),
+                h2: const TextStyle(fontSize: 20),
+                h2Padding: const EdgeInsets.only(top: 16),
+                h3: const TextStyle(fontSize: 14),
+                p: const TextStyle(fontSize: 14),
+                h3Padding: const EdgeInsets.only(top: 16),
+              ),
+              onTapLink: (text, href, title) {
+                if (href != null) {
+                  launchUrlString(
+                    href,
+                    mode: context.read<SettingsStore>().launchUrlExternal
+                        ? LaunchMode.externalApplication
+                        : LaunchMode.inAppBrowserView,
+                  );
+                }
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/settings/widgets/release_notes.dart
+++ b/lib/screens/settings/widgets/release_notes.dart
@@ -40,12 +40,12 @@ class _ReleaseNotesState extends State<ReleaseNotes> {
             child: Markdown(
               data: releaseNotes,
               styleSheet: MarkdownStyleSheet(
-                h1: const TextStyle(fontSize: 24),
                 h2: const TextStyle(fontSize: 20),
-                h2Padding: const EdgeInsets.only(top: 16),
-                h3: const TextStyle(fontSize: 14),
-                p: const TextStyle(fontSize: 14),
+                h3: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
                 h3Padding: const EdgeInsets.only(top: 16),
+                h4: const TextStyle(fontSize: 14),
+                h4Padding: const EdgeInsets.only(top: 16),
+                p: const TextStyle(fontSize: 14),
               ),
               onTapLink: (text, href, title) {
                 if (href != null) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -427,6 +427,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  flutter_markdown:
+    dependency: "direct main"
+    description:
+      name: flutter_markdown
+      sha256: a23c41ee57573e62fc2190a1f36a0480c4d90bde3a8a8d7126e5d5992fb53fb7
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.3+1"
   flutter_mobx:
     dependency: "direct main"
     description:
@@ -677,6 +685,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.2-main.4"
+  markdown:
+    dependency: transitive
+    description:
+      name: markdown
+      sha256: ef2a1298144e3f985cc736b22e0ccdaf188b5b3970648f2d9dc13efd1d9df051
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.2"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,6 +65,7 @@ dependencies:
   webview_flutter_android: ^3.7.0
   webview_flutter_wkwebview: ^3.4.3
   photo_view: ^0.15.0
+  flutter_markdown: ^0.7.3+1
 
 dev_dependencies:
   flutter_test:
@@ -123,6 +124,7 @@ flutter:
   assets:
     - assets/icons/logo.svg
     - assets/fonts/
+    - assets/release-notes.md
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/to/resolution-aware-images


### PR DESCRIPTION
This PR adds a release notes page when launching the app on a new release. Uses the flutter markdown package to convert a local markdown file into a release notes page.