### PR TITLE
Show video quality settings on iPad

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'package:frosty/screens/onboarding/onboarding_intro.dart';
 import 'package:frosty/screens/settings/stores/auth_store.dart';
 import 'package:frosty/screens/settings/stores/settings_store.dart';
 import 'package:frosty/theme.dart';
+import 'package:frosty/utils.dart';
 import 'package:http/http.dart';
 import 'package:mobx/mobx.dart';
 import 'package:provider/provider.dart';
@@ -50,6 +51,8 @@ void main() async {
 
     await storage.deleteAll();
   }
+
+  await initUtils();
 
   // With the shared preferences instance, obtain the existing user settings if it exists.
   // If default settings don't exist, use an empty JSON string to use the default values.

--- a/lib/screens/channel/video/video_overlay.dart
+++ b/lib/screens/channel/video/video_overlay.dart
@@ -8,6 +8,7 @@ import 'package:frosty/screens/channel/chat/stores/chat_store.dart';
 import 'package:frosty/screens/channel/video/video_bar.dart';
 import 'package:frosty/screens/channel/video/video_store.dart';
 import 'package:frosty/screens/settings/stores/settings_store.dart';
+import 'package:frosty/utils.dart';
 import 'package:frosty/widgets/section_header.dart';
 import 'package:frosty/widgets/uptime.dart';
 import 'package:intl/intl.dart';
@@ -201,7 +202,9 @@ class VideoOverlay extends StatelessWidget {
                   mainAxisAlignment: MainAxisAlignment.end,
                   children: [
                     refreshButton,
-                    if (!videoStore.isIPad) rotateButton,
+                    // On iPad, hide the rotate button on the overlay
+                    // Flutter doesn't allow programmatic rotation on iPad unless multitasking is disabled.
+                    if (!isIPad()) rotateButton,
                     if (orientation == Orientation.landscape) fullScreenButton,
                   ],
                 ),
@@ -229,7 +232,7 @@ class VideoOverlay extends StatelessWidget {
                 if (videoStore.settingsStore.fullScreen &&
                     orientation == Orientation.landscape)
                   chatOverlayButton,
-                if (!Platform.isIOS) videoSettingsButton,
+                if (!Platform.isIOS || isIPad()) videoSettingsButton,
               ],
             ),
             Center(
@@ -343,7 +346,9 @@ class VideoOverlay extends StatelessWidget {
                     ),
                   ),
                   refreshButton,
-                  if (!videoStore.isIPad) rotateButton,
+                  // On iPad, hide the rotate button on the overlay
+                  // Flutter doesn't allow programmatic rotation on iPad unless multitasking is disabled.
+                  if (!isIPad()) rotateButton,
                   if (orientation == Orientation.landscape) fullScreenButton,
                 ],
               ),

--- a/lib/screens/channel/video/video_store.dart
+++ b/lib/screens/channel/video/video_store.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:frosty/apis/twitch_api.dart';
@@ -117,10 +116,6 @@ abstract class VideoStoreBase with Store {
   /// If the overlay is should be visible.
   @readonly
   var _overlayVisible = true;
-
-  /// If the current device is iPad.
-  @readonly
-  var _isIPad = false;
 
   /// The current stream info, used for displaying relevant info on the overlay.
   @readonly
@@ -362,19 +357,6 @@ abstract class VideoStoreBase with Store {
         }
       } catch (e) {
         debugPrint(e.toString());
-      }
-    }
-
-    // Determine whether the device is an iPad or not.
-    // Used to show or hide the rotate button on the overlay.
-    // Flutter doesn't allow programmatic rotation on iPad unless multitasking is disabled.
-    if (Platform.isIOS) {
-      final deviceInfo = DeviceInfoPlugin();
-      final info = await deviceInfo.iosInfo;
-      if (info.model.toLowerCase().contains('ipad')) {
-        _isIPad = true;
-      } else {
-        _isIPad = false;
       }
     }
   }

--- a/lib/screens/channel/video/video_store.g.dart
+++ b/lib/screens/channel/video/video_store.g.dart
@@ -45,24 +45,6 @@ mixin _$VideoStore on VideoStoreBase, Store {
     });
   }
 
-  late final _$_isIPadAtom =
-      Atom(name: 'VideoStoreBase._isIPad', context: context);
-
-  bool get isIPad {
-    _$_isIPadAtom.reportRead();
-    return super._isIPad;
-  }
-
-  @override
-  bool get _isIPad => isIPad;
-
-  @override
-  set _isIPad(bool value) {
-    _$_isIPadAtom.reportWrite(value, super._isIPad, () {
-      super._isIPad = value;
-    });
-  }
-
   late final _$_streamInfoAtom =
       Atom(name: 'VideoStoreBase._streamInfo', context: context);
 

--- a/lib/screens/settings/video_settings.dart
+++ b/lib/screens/settings/video_settings.dart
@@ -5,6 +5,7 @@ import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:frosty/screens/settings/stores/settings_store.dart';
 import 'package:frosty/screens/settings/widgets/settings_list_slider.dart';
 import 'package:frosty/screens/settings/widgets/settings_list_switch.dart';
+import 'package:frosty/utils.dart';
 import 'package:frosty/widgets/section_header.dart';
 
 class VideoSettings extends StatelessWidget {
@@ -23,7 +24,7 @@ class VideoSettings extends StatelessWidget {
             value: settingsStore.showVideo,
             onChanged: (newValue) => settingsStore.showVideo = newValue,
           ),
-          if (!Platform.isIOS)
+          if (!Platform.isIOS || isIPad())
             SettingsListSwitch(
               title: 'Default to highest quality',
               value: settingsStore.defaultToHighestQuality,

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:frosty/constants.dart';
 
 String getReadableName(String displayName, String username) {
@@ -6,4 +9,21 @@ String getReadableName(String displayName, String username) {
   }
 
   return displayName;
+}
+
+var _isIPad = false;
+
+bool isIPad() {
+  return _isIPad;
+}
+
+Future<void> initUtils() async {
+  // Determine whether the device is an iPad or not.
+  if (Platform.isIOS) {
+    final deviceInfo = DeviceInfoPlugin();
+    final info = await deviceInfo.iosInfo;
+    if (info.model.toLowerCase().contains('ipad')) {
+      _isIPad = true;
+    }
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/tommyxchow/frosty/issues/341

Example screenshot of the video player on iPad, using the custom overlay with "Default to highest quality" enabled.

<img src="https://github.com/user-attachments/assets/2c0e9612-bed1-45fa-a323-d8e48392dec1" width="420">