### PR TITLE
Move exact matches of searched categories to the top

### DIFF
--- a/lib/screens/home/search/search_store.dart
+++ b/lib/screens/home/search/search_store.dart
@@ -83,6 +83,16 @@ abstract class SearchStoreBase with Store {
           query: query,
           headers: authStore.headersTwitch,
         )
+        .then((categories) {
+          // Move exact matches to the first result
+          final matchingIndex = categories.data
+              .indexWhere((c) => c.name.toLowerCase() == query.toLowerCase());
+          if (matchingIndex >= 1) {
+            final matchingCategory = categories.data.removeAt(matchingIndex);
+            categories.data.insert(0, matchingCategory);
+          }
+          return categories;
+        })
         .asObservable();
   }
 


### PR DESCRIPTION
When searching for games like "TEKKEN 8" or "Street Fighter 6", I have to scroll down quite far to find the actual category.

This PR moves category search results which exactly match the search query to the top of the list.

Example when searching "street fighter 6":

| Before | After |
|-|-|
|![sf6-before](https://github.com/user-attachments/assets/ff7646c6-0913-485a-bf08-7f7a4cf52b9b)|![sf6-after](https://github.com/user-attachments/assets/963673a0-b6ad-48b5-a12d-9ac35ce6bd5d)|