### PR TITLE
Improve initial playback stability

### DIFF
--- a/lib/screens/channel/video/video_store.dart
+++ b/lib/screens/channel/video/video_store.dart
@@ -311,21 +311,17 @@ abstract class VideoStoreBase with Store {
             observer.observe(document.body, { childList: true, subtree: true });
           });
 
-          (function checkVideoElement() {
-            const videoElement = document.getElementsByTagName("video")[0];
-            if (videoElement) {
-              videoElement.addEventListener("pause", () => {
-                VideoPause.postMessage("video paused");
-                videoElement.textTracks[0].mode = "hidden";
-              });
-              videoElement.addEventListener("playing", () => {
-                VideoPlaying.postMessage("video playing");
-                videoElement.textTracks[0].mode = "hidden";
-              });
-            } else {
-              setTimeout(checkVideoElement, 100); // Check again after 100ms
-            }
-          })();
+          _queuePromise(async () => {
+            const videoElement = await _asyncQuerySelector("video");
+            videoElement.addEventListener("pause", () => {
+              VideoPause.postMessage("video paused");
+              videoElement.textTracks[0].mode = "hidden";
+            });
+            videoElement.addEventListener("playing", () => {
+              VideoPlaying.postMessage("video playing");
+              videoElement.textTracks[0].mode = "hidden";
+            });
+          });
         ''');
         if (settingsStore.showOverlay) {
           await _hideDefaultOverlay();

--- a/lib/screens/channel/video/video_store.dart
+++ b/lib/screens/channel/video/video_store.dart
@@ -191,29 +191,15 @@ abstract class VideoStoreBase with Store {
   Future<void> updateStreamQualities() async {
     try {
       await videoWebViewController.runJavaScript('''
-        {
-          const asyncQuerySelector = (selector) => new Promise((resolve) => {
-            if (document.querySelector(selector)) {
-              return resolve(document.querySelector(selector));
-            }
-            const observer = new MutationObserver((mutations) => {
-              if (document.querySelector(selector)) {
-                observer.disconnect();
-                resolve(document.querySelector(selector));
-              }
-            });
-            observer.observe(document.body, { childList: true, subtree: true });
-          });
-          (async () => {
-            (await asyncQuerySelector('[data-a-target="player-settings-button"]')).click();
-            (await asyncQuerySelector('[data-a-target="player-settings-menu-item-quality"]')).click();
-            await asyncQuerySelector('[data-a-target="player-settings-submenu-quality-option"] label div');
-            const qualities = [...document.querySelectorAll('[data-a-target="player-settings-submenu-quality-option"] label div')].map((el) => el.textContent);
-            StreamQualities.postMessage(JSON.stringify(qualities));
-            (await asyncQuerySelector('.tw-drop-down-menu-item-figure')).click();
-            (await asyncQuerySelector('[data-a-target="player-settings-menu"] [role="menuitem"] button')).click();
-          })();
-        }
+        _queuePromise(async () => {
+          (await _asyncQuerySelector('[data-a-target="player-settings-button"]')).click();
+          (await _asyncQuerySelector('[data-a-target="player-settings-menu-item-quality"]')).click();
+          await _asyncQuerySelector('[data-a-target="player-settings-submenu-quality-option"] label div');
+          const qualities = [...document.querySelectorAll('[data-a-target="player-settings-submenu-quality-option"] label div')].map((el) => el.textContent);
+          StreamQualities.postMessage(JSON.stringify(qualities));
+          (await _asyncQuerySelector('.tw-drop-down-menu-item-figure')).click();
+          (await _asyncQuerySelector('[data-a-target="player-settings-menu"] [role="menuitem"] button')).click();
+        });
       ''');
     } catch (e) {
       debugPrint(e.toString());
@@ -231,28 +217,14 @@ abstract class VideoStoreBase with Store {
   Future<void> _setStreamQualityIndex(int newStreamQualityIndex) async {
     try {
       await videoWebViewController.runJavaScript('''
-        {
-          const asyncQuerySelector = (selector) => new Promise((resolve) => {
-            if (document.querySelector(selector)) {
-              return resolve(document.querySelector(selector));
-            }
-            const observer = new MutationObserver((mutations) => {
-              if (document.querySelector(selector)) {
-                observer.disconnect();
-                resolve(document.querySelector(selector));
-              }
-            });
-            observer.observe(document.body, { childList: true, subtree: true });
-          });
-          (async () => {
-            (await asyncQuerySelector('[data-a-target="player-settings-button"]')).click();
-            (await asyncQuerySelector('[data-a-target="player-settings-menu-item-quality"]')).click();
-            await asyncQuerySelector('[data-a-target="player-settings-submenu-quality-option"] input');
-            [...document.querySelectorAll('[data-a-target="player-settings-submenu-quality-option"] input')][$newStreamQualityIndex].click();
-            (await asyncQuerySelector('.tw-drop-down-menu-item-figure')).click();
-            (await asyncQuerySelector('[data-a-target="player-settings-menu"] [role="menuitem"] button')).click();
-          })();
-        }
+        _queuePromise(async () => {
+          (await _asyncQuerySelector('[data-a-target="player-settings-button"]')).click();
+          (await _asyncQuerySelector('[data-a-target="player-settings-menu-item-quality"]')).click();
+          await _asyncQuerySelector('[data-a-target="player-settings-submenu-quality-option"] input');
+          [...document.querySelectorAll('[data-a-target="player-settings-submenu-quality-option"] input')][$newStreamQualityIndex].click();
+          (await _asyncQuerySelector('.tw-drop-down-menu-item-figure')).click();
+          (await _asyncQuerySelector('[data-a-target="player-settings-menu"] [role="menuitem"] button')).click();
+        });
       ''');
       _streamQualityIndex = newStreamQualityIndex;
     } catch (e) {
@@ -294,32 +266,18 @@ abstract class VideoStoreBase with Store {
   Future<void> _listenOnLatencyChanges() async {
     try {
       await videoWebViewController.runJavaScript('''
-        {
-          const asyncQuerySelector = (selector) => new Promise((resolve) => {
-            if (document.querySelector(selector)) {
-              return resolve(document.querySelector(selector));
-            }
-            const observer = new MutationObserver((mutations) => {
-              if (document.querySelector(selector)) {
-                observer.disconnect();
-                resolve(document.querySelector(selector));
-              }
-            });
-            observer.observe(document.body, { childList: true, subtree: true });
-          });
-          (async () => {
-            (await asyncQuerySelector('[data-a-target="player-settings-button"]')).click();
-            (await asyncQuerySelector('[data-a-target="player-settings-menu-item-advanced"]')).click();
-            (await asyncQuerySelector('[data-a-target="player-settings-submenu-advanced-video-stats"] input')).click();
-            (await asyncQuerySelector('.tw-drop-down-menu-item-figure')).click();
-            (await asyncQuerySelector('[data-a-target="player-settings-menu"] [role="menuitem"] button')).click();
-            (await asyncQuerySelector('[data-a-target="player-overlay-video-stats"]')).style.display = "none";
-            const observer = new MutationObserver((changes) => {
-              Latency.postMessage(changes[0].target.textContent);
-            })
-            observer.observe(document.querySelector('[aria-label="Latency To Broadcaster"]'), { characterData: true, attributes: false, childList: false, subtree: true });
-          })();
-        }
+        _queuePromise(async () => {
+          (await _asyncQuerySelector('[data-a-target="player-settings-button"]')).click();
+          (await _asyncQuerySelector('[data-a-target="player-settings-menu-item-advanced"]')).click();
+          (await _asyncQuerySelector('[data-a-target="player-settings-submenu-advanced-video-stats"] input')).click();
+          (await _asyncQuerySelector('.tw-drop-down-menu-item-figure')).click();
+          (await _asyncQuerySelector('[data-a-target="player-settings-menu"] [role="menuitem"] button')).click();
+          (await _asyncQuerySelector('[data-a-target="player-overlay-video-stats"]')).style.display = "none";
+          const observer = new MutationObserver((changes) => {
+            Latency.postMessage(changes[0].target.textContent);
+          })
+          observer.observe(document.querySelector('[aria-label="Latency To Broadcaster"]'), { characterData: true, attributes: false, childList: false, subtree: true });
+        });
       ''');
     } catch (e) {
       debugPrint(e.toString());
@@ -330,27 +288,45 @@ abstract class VideoStoreBase with Store {
   @action
   Future<void> initVideo() async {
     if (await videoWebViewController.currentUrl() == videoUrl) {
-      // Add event listeners to notify the JavaScript channels when the video plays and pauses.
+      // Declare `window` level utility methods and add event listeners to notify the JavaScript channels when the video plays and pauses.
       try {
-        videoWebViewController.runJavaScript(
-          '''
-        (function checkVideoElement() {
-          const videoElement = document.getElementsByTagName("video")[0];
-          if (videoElement) {
-            videoElement.addEventListener("pause", () => {
-              VideoPause.postMessage("video paused");
-              videoElement.textTracks[0].mode = "hidden";
+        videoWebViewController.runJavaScript('''
+          window._PROMISE_QUEUE = Promise.resolve();
+          window._queuePromise = (method) => {
+            window._PROMISE_QUEUE = window._PROMISE_QUEUE.then(method, method);
+            return window._PROMISE_QUEUE;
+          };
+          window._asyncQuerySelector = (selector) => new Promise((resolve) => {
+            let element = document.querySelector(selector);
+            if (element) {
+              return resolve(element);
+            }
+            const observer = new MutationObserver(() => {
+              element = document.querySelector(selector);
+              if (element) {
+                observer.disconnect();
+                resolve(element);
+              }
             });
-            videoElement.addEventListener("playing", () => {
-              VideoPlaying.postMessage("video playing");
-              videoElement.textTracks[0].mode = "hidden";
-            });
-          } else {
-            setTimeout(checkVideoElement, 100); // Check again after 100ms
-          }
-        })();
-        ''',
-        );
+            observer.observe(document.body, { childList: true, subtree: true });
+          });
+
+          (function checkVideoElement() {
+            const videoElement = document.getElementsByTagName("video")[0];
+            if (videoElement) {
+              videoElement.addEventListener("pause", () => {
+                VideoPause.postMessage("video paused");
+                videoElement.textTracks[0].mode = "hidden";
+              });
+              videoElement.addEventListener("playing", () => {
+                VideoPlaying.postMessage("video playing");
+                videoElement.textTracks[0].mode = "hidden";
+              });
+            } else {
+              setTimeout(checkVideoElement, 100); // Check again after 100ms
+            }
+          })();
+        ''');
         if (settingsStore.showOverlay) {
           await _hideDefaultOverlay();
           await _listenOnLatencyChanges();


### PR DESCRIPTION
This PR fixes two issues I've occasionally been running into when opening a stream.

1. [Add window-level promise queuing and _asyncQuerySelector](https://github.com/tommyxchow/frosty/commit/c338c609246ec9b9f7e33c87ec002fe31c8dfb3a):
   - When defaulting to the highest quality with the custom overlay, sometimes the highest quality will be "selected" in the overlay, but the actual playback will still be using the default "Auto" quality. Refreshing the stream or manually reselecting the highest quality are some workarounds.
   - I believe this is caused by a race condition where `_listenOnLatencyChanges` and `_setStreamQualityIndex` attempt to interact with the settings elements at the same time.
   - Prevent this by introducing a promise queue.
2. [Use _asyncQuerySelector to initialize video element](https://github.com/tommyxchow/frosty/commit/722fa6809211ce5a554ce15da357faa90fa7b983):
   - The overlay sometimes gets stuck in the "paused" state. I think 3bcb1c35945246f7b3d139a6cf5796a2b7d1193e partially fixed this issue.
   - The issue occurs when the retried `videoElement.addEventListener("playing", ...)` is called after the player has already started playing. I tested this theory with the patch below.
   - Fix this by using `_asyncQuerySelector` to get the video element for the first time, removing the retry behaviour.

<details>
<summary>Patch for verifying the second issue</summary>

```diff
diff --git a/lib/screens/channel/video/video_store.dart b/lib/screens/channel/video/video_store.dart
index f39fdb5..935b13d 100644
--- a/lib/screens/channel/video/video_store.dart
+++ b/lib/screens/channel/video/video_store.dart
@@ -334,9 +334,9 @@ abstract class VideoStoreBase with Store {
       try {
         videoWebViewController.runJavaScript(
           '''
-        (function checkVideoElement() {
+        (function checkVideoElement(first) {
           const videoElement = document.getElementsByTagName("video")[0];
-          if (videoElement) {
+          if (videoElement && !first) {
             videoElement.addEventListener("pause", () => {
               VideoPause.postMessage("video paused");
               videoElement.textTracks[0].mode = "hidden";
@@ -346,9 +346,9 @@ abstract class VideoStoreBase with Store {
               videoElement.textTracks[0].mode = "hidden";
             });
           } else {
-            setTimeout(checkVideoElement, 100); // Check again after 100ms
+            setTimeout(checkVideoElement, 2000); // Check again after 2s
           }
-        })();
+        })(true);
         ''',
         );
         if (settingsStore.showOverlay) {
```
</details>