### PR TITLE
Add ability to mute keywords from chat

### DIFF
--- a/lib/screens/channel/chat/stores/chat_store.dart
+++ b/lib/screens/channel/chat/stores/chat_store.dart
@@ -311,6 +311,21 @@ abstract class ChatStoreBase with Store {
           continue;
         }
 
+        // Filter messages containing any muted words.
+        if (parsedIRCMessage.message != null) {
+          final List<String> mutedWords = settings.mutedWords;
+
+          // check if the message contains any of the muted words
+          for (String word in mutedWords) {
+            if (parsedIRCMessage.message!
+                .toLowerCase()
+                .split(settings.matchWholeWord ? ' ' : '')
+                .contains(word.toLowerCase())) {
+              return;
+            }
+          }
+        }
+
         switch (parsedIRCMessage.command) {
           case Command.privateMessage:
           case Command.notice:

--- a/lib/screens/channel/chat/stores/chat_store.dart
+++ b/lib/screens/channel/chat/stores/chat_store.dart
@@ -316,7 +316,7 @@ abstract class ChatStoreBase with Store {
           final List<String> mutedWords = settings.mutedWords;
 
           // check if the message contains any of the muted words
-          for (String word in mutedWords) {
+          for (final word in mutedWords) {
             if (parsedIRCMessage.message!
                 .toLowerCase()
                 .split(settings.matchWholeWord ? ' ' : '')

--- a/lib/screens/settings/chat_settings.dart
+++ b/lib/screens/settings/chat_settings.dart
@@ -8,6 +8,7 @@ import 'package:frosty/screens/settings/stores/settings_store.dart';
 import 'package:frosty/screens/settings/widgets/settings_list_select.dart';
 import 'package:frosty/screens/settings/widgets/settings_list_slider.dart';
 import 'package:frosty/screens/settings/widgets/settings_list_switch.dart';
+import 'package:frosty/screens/settings/widgets/settings_muted_words.dart';
 import 'package:frosty/widgets/cached_image.dart';
 import 'package:frosty/widgets/section_header.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -283,6 +284,16 @@ class _ChatSettingsState extends State<ChatSettings> {
             value: settingsStore.chatOnlyPreventSleep,
             onChanged: (newValue) =>
                 settingsStore.chatOnlyPreventSleep = newValue,
+          ),
+          const SectionHeader('Muted keywords'),
+          SettingsMutedWords(settingsStore: settingsStore),
+          SettingsListSwitch(
+            title: 'Match whole words',
+            subtitle: const Text(
+              'Only matches whole words instead of partial matches.',
+            ),
+            value: settingsStore.matchWholeWord,
+            onChanged: (newValue) => settingsStore.matchWholeWord = newValue,
           ),
           const SectionHeader('Autocomplete'),
           SettingsListSwitch(

--- a/lib/screens/settings/stores/settings_store.dart
+++ b/lib/screens/settings/stores/settings_store.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:mobx/mobx.dart';
 

--- a/lib/screens/settings/stores/settings_store.dart
+++ b/lib/screens/settings/stores/settings_store.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:mobx/mobx.dart';
 
@@ -143,6 +144,10 @@ abstract class _SettingsStoreBase with Store {
 
   // Sleep defaults
   static const defaultChatOnlyPreventSleep = false;
+
+  // mute words defaults
+  static const defaultMutedWords = <String>[];
+  static const defaultMatchWholeWord = false;
 
   // Autocomplete defaults
   static const defaultAutocomplete = true;
@@ -301,6 +306,45 @@ abstract class _SettingsStoreBase with Store {
   @observable
   var darkenRecentMessages = defaultDarkenRecentMessages;
 
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  TextEditingController textController = TextEditingController();
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @computed
+  String get textControllerText => textController.text;
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @computed
+  bool get textControllerTextIsEmpty => textController.text.isEmpty;
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  FocusNode textFieldFocusNode = FocusNode();
+
+  @JsonKey(defaultValue: defaultMutedWords)
+  @observable
+  List<String> mutedWords = List.from(defaultMutedWords);
+
+  @JsonKey(defaultValue: defaultMatchWholeWord)
+  @observable
+  bool matchWholeWord = defaultMatchWholeWord;
+
+  @action
+  void addMutedWord(String text) {
+    mutedWords.add(text);
+
+    // update the list: this is necessary because the list is not an ObservableList
+    // we cannot really have an ObservableList because it's hard to serialize
+    mutedWords = List.from(mutedWords);
+
+    textController.clear();
+    textFieldFocusNode.unfocus();
+  }
+
+  void removeMutedWord(int index) {
+    mutedWords.removeAt(index);
+    mutedWords = List.from(mutedWords);
+  }
+
   @action
   void resetChatSettings() {
     badgeScale = defaultBadgeScale;
@@ -331,6 +375,10 @@ abstract class _SettingsStoreBase with Store {
     fullScreenChatOverlayOpacity = defaultFullScreenChatOverlayOpacity;
 
     chatOnlyPreventSleep = defaultChatOnlyPreventSleep;
+
+    mutedWords = defaultMutedWords;
+    matchWholeWord = defaultMatchWholeWord;
+
     autocomplete = defaultAutocomplete;
 
     showTwitchEmotes = defaultShowTwitchEmotes;

--- a/lib/screens/settings/stores/settings_store.dart
+++ b/lib/screens/settings/stores/settings_store.dart
@@ -146,11 +146,7 @@ abstract class _SettingsStoreBase with Store {
   static const defaultChatOnlyPreventSleep = false;
 
   // mute words defaults
-  // This static function is required to create a new instance of ObservableList for the JSON serialization
-  static ObservableList<String> getDefaultMutedWords() {
-    return ObservableList<String>();
-  }
-
+  static const defaultMutedWords = <String>[];
   static const defaultMatchWholeWord = true;
 
   // Autocomplete defaults
@@ -310,10 +306,9 @@ abstract class _SettingsStoreBase with Store {
   @observable
   var darkenRecentMessages = defaultDarkenRecentMessages;
 
-  @JsonKey(defaultValue: getDefaultMutedWords)
-  @ObservableMutedWordsListConverter()
+  @JsonKey(defaultValue: defaultMutedWords)
   @observable
-  ObservableList<String> mutedWords = getDefaultMutedWords();
+  List<String> mutedWords = defaultMutedWords;
 
   @JsonKey(defaultValue: defaultMatchWholeWord)
   @observable
@@ -350,7 +345,7 @@ abstract class _SettingsStoreBase with Store {
 
     chatOnlyPreventSleep = defaultChatOnlyPreventSleep;
 
-    mutedWords = getDefaultMutedWords();
+    mutedWords = defaultMutedWords;
     matchWholeWord = defaultMatchWholeWord;
 
     autocomplete = defaultAutocomplete;
@@ -436,18 +431,4 @@ enum LandscapeCutoutType {
   left,
   right,
   both,
-}
-
-/// A [JsonConverter] that serializes [ObservableList<String>] to a list of strings.
-class ObservableMutedWordsListConverter
-    extends JsonConverter<ObservableList<String>, List<dynamic>> {
-  const ObservableMutedWordsListConverter();
-
-  @override
-  ObservableList<String> fromJson(List<dynamic> json) =>
-      ObservableList.of(json.map((e) => e['word'] as String));
-
-  @override
-  List<Map<String, dynamic>> toJson(ObservableList<String> object) =>
-      object.map((element) => {'word': element}).toList();
 }

--- a/lib/screens/settings/stores/settings_store.g.dart
+++ b/lib/screens/settings/stores/settings_store.g.dart
@@ -64,6 +64,11 @@ SettingsStore _$SettingsStoreFromJson(Map<String, dynamic> json) =>
       ..showFFZBadges = json['showFFZBadges'] as bool? ?? true
       ..showRecentMessages = json['showRecentMessages'] as bool? ?? false
       ..darkenRecentMessages = json['darkenRecentMessages'] as bool? ?? true
+      ..mutedWords = (json['mutedWords'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          []
+      ..matchWholeWord = json['matchWholeWord'] as bool? ?? false
       ..shareCrashLogsAndAnalytics =
           json['shareCrashLogsAndAnalytics'] as bool? ?? true
       ..fullScreen = json['fullScreen'] as bool? ?? false
@@ -119,6 +124,8 @@ Map<String, dynamic> _$SettingsStoreToJson(SettingsStore instance) =>
       'showFFZBadges': instance.showFFZBadges,
       'showRecentMessages': instance.showRecentMessages,
       'darkenRecentMessages': instance.darkenRecentMessages,
+      'mutedWords': instance.mutedWords,
+      'matchWholeWord': instance.matchWholeWord,
       'shareCrashLogsAndAnalytics': instance.shareCrashLogsAndAnalytics,
       'fullScreen': instance.fullScreen,
       'fullScreenChatOverlay': instance.fullScreenChatOverlay,
@@ -151,6 +158,21 @@ const _$LandscapeCutoutTypeEnumMap = {
 // ignore_for_file: non_constant_identifier_names, unnecessary_brace_in_string_interps, unnecessary_lambdas, prefer_expression_function_bodies, lines_longer_than_80_chars, avoid_as, avoid_annotating_with_dynamic, no_leading_underscores_for_local_identifiers
 
 mixin _$SettingsStore on _SettingsStoreBase, Store {
+  Computed<String>? _$textControllerTextComputed;
+
+  @override
+  String get textControllerText => (_$textControllerTextComputed ??=
+          Computed<String>(() => super.textControllerText,
+              name: '_SettingsStoreBase.textControllerText'))
+      .value;
+  Computed<bool>? _$textControllerTextIsEmptyComputed;
+
+  @override
+  bool get textControllerTextIsEmpty => (_$textControllerTextIsEmptyComputed ??=
+          Computed<bool>(() => super.textControllerTextIsEmpty,
+              name: '_SettingsStoreBase.textControllerTextIsEmpty'))
+      .value;
+
   late final _$themeTypeAtom =
       Atom(name: '_SettingsStoreBase.themeType', context: context);
 
@@ -850,6 +872,38 @@ mixin _$SettingsStore on _SettingsStoreBase, Store {
     });
   }
 
+  late final _$mutedWordsAtom =
+      Atom(name: '_SettingsStoreBase.mutedWords', context: context);
+
+  @override
+  List<String> get mutedWords {
+    _$mutedWordsAtom.reportRead();
+    return super.mutedWords;
+  }
+
+  @override
+  set mutedWords(List<String> value) {
+    _$mutedWordsAtom.reportWrite(value, super.mutedWords, () {
+      super.mutedWords = value;
+    });
+  }
+
+  late final _$matchWholeWordAtom =
+      Atom(name: '_SettingsStoreBase.matchWholeWord', context: context);
+
+  @override
+  bool get matchWholeWord {
+    _$matchWholeWordAtom.reportRead();
+    return super.matchWholeWord;
+  }
+
+  @override
+  set matchWholeWord(bool value) {
+    _$matchWholeWordAtom.reportWrite(value, super.matchWholeWord, () {
+      super.matchWholeWord = value;
+    });
+  }
+
   late final _$shareCrashLogsAndAnalyticsAtom = Atom(
       name: '_SettingsStoreBase.shareCrashLogsAndAnalytics', context: context);
 
@@ -936,6 +990,17 @@ mixin _$SettingsStore on _SettingsStoreBase, Store {
         name: '_SettingsStoreBase.resetVideoSettings');
     try {
       return super.resetVideoSettings();
+    } finally {
+      _$_SettingsStoreBaseActionController.endAction(_$actionInfo);
+    }
+  }
+
+  @override
+  void addMutedWord(String text) {
+    final _$actionInfo = _$_SettingsStoreBaseActionController.startAction(
+        name: '_SettingsStoreBase.addMutedWord');
+    try {
+      return super.addMutedWord(text);
     } finally {
       _$_SettingsStoreBaseActionController.endAction(_$actionInfo);
     }
@@ -1031,10 +1096,14 @@ showFFZEmotes: ${showFFZEmotes},
 showFFZBadges: ${showFFZBadges},
 showRecentMessages: ${showRecentMessages},
 darkenRecentMessages: ${darkenRecentMessages},
+mutedWords: ${mutedWords},
+matchWholeWord: ${matchWholeWord},
 shareCrashLogsAndAnalytics: ${shareCrashLogsAndAnalytics},
 fullScreen: ${fullScreen},
 fullScreenChatOverlay: ${fullScreenChatOverlay},
-pinnedChannelIds: ${pinnedChannelIds}
+pinnedChannelIds: ${pinnedChannelIds},
+textControllerText: ${textControllerText},
+textControllerTextIsEmpty: ${textControllerTextIsEmpty}
     ''';
   }
 }

--- a/lib/screens/settings/stores/settings_store.g.dart
+++ b/lib/screens/settings/stores/settings_store.g.dart
@@ -64,11 +64,11 @@ SettingsStore _$SettingsStoreFromJson(Map<String, dynamic> json) =>
       ..showFFZBadges = json['showFFZBadges'] as bool? ?? true
       ..showRecentMessages = json['showRecentMessages'] as bool? ?? false
       ..darkenRecentMessages = json['darkenRecentMessages'] as bool? ?? true
-      ..mutedWords = (json['mutedWords'] as List<dynamic>?)
-              ?.map((e) => e as String)
-              .toList() ??
-          []
-      ..matchWholeWord = json['matchWholeWord'] as bool? ?? false
+      ..mutedWords = json['mutedWords'] == null
+          ? _SettingsStoreBase.getDefaultMutedWords()
+          : const ObservableMutedWordsListConverter()
+              .fromJson(json['mutedWords'] as List)
+      ..matchWholeWord = json['matchWholeWord'] as bool? ?? true
       ..shareCrashLogsAndAnalytics =
           json['shareCrashLogsAndAnalytics'] as bool? ?? true
       ..fullScreen = json['fullScreen'] as bool? ?? false
@@ -124,7 +124,8 @@ Map<String, dynamic> _$SettingsStoreToJson(SettingsStore instance) =>
       'showFFZBadges': instance.showFFZBadges,
       'showRecentMessages': instance.showRecentMessages,
       'darkenRecentMessages': instance.darkenRecentMessages,
-      'mutedWords': instance.mutedWords,
+      'mutedWords':
+          const ObservableMutedWordsListConverter().toJson(instance.mutedWords),
       'matchWholeWord': instance.matchWholeWord,
       'shareCrashLogsAndAnalytics': instance.shareCrashLogsAndAnalytics,
       'fullScreen': instance.fullScreen,
@@ -158,21 +159,6 @@ const _$LandscapeCutoutTypeEnumMap = {
 // ignore_for_file: non_constant_identifier_names, unnecessary_brace_in_string_interps, unnecessary_lambdas, prefer_expression_function_bodies, lines_longer_than_80_chars, avoid_as, avoid_annotating_with_dynamic, no_leading_underscores_for_local_identifiers
 
 mixin _$SettingsStore on _SettingsStoreBase, Store {
-  Computed<String>? _$textControllerTextComputed;
-
-  @override
-  String get textControllerText => (_$textControllerTextComputed ??=
-          Computed<String>(() => super.textControllerText,
-              name: '_SettingsStoreBase.textControllerText'))
-      .value;
-  Computed<bool>? _$textControllerTextIsEmptyComputed;
-
-  @override
-  bool get textControllerTextIsEmpty => (_$textControllerTextIsEmptyComputed ??=
-          Computed<bool>(() => super.textControllerTextIsEmpty,
-              name: '_SettingsStoreBase.textControllerTextIsEmpty'))
-      .value;
-
   late final _$themeTypeAtom =
       Atom(name: '_SettingsStoreBase.themeType', context: context);
 
@@ -876,13 +862,13 @@ mixin _$SettingsStore on _SettingsStoreBase, Store {
       Atom(name: '_SettingsStoreBase.mutedWords', context: context);
 
   @override
-  List<String> get mutedWords {
+  ObservableList<String> get mutedWords {
     _$mutedWordsAtom.reportRead();
     return super.mutedWords;
   }
 
   @override
-  set mutedWords(List<String> value) {
+  set mutedWords(ObservableList<String> value) {
     _$mutedWordsAtom.reportWrite(value, super.mutedWords, () {
       super.mutedWords = value;
     });
@@ -996,17 +982,6 @@ mixin _$SettingsStore on _SettingsStoreBase, Store {
   }
 
   @override
-  void addMutedWord(String text) {
-    final _$actionInfo = _$_SettingsStoreBaseActionController.startAction(
-        name: '_SettingsStoreBase.addMutedWord');
-    try {
-      return super.addMutedWord(text);
-    } finally {
-      _$_SettingsStoreBaseActionController.endAction(_$actionInfo);
-    }
-  }
-
-  @override
   void resetChatSettings() {
     final _$actionInfo = _$_SettingsStoreBaseActionController.startAction(
         name: '_SettingsStoreBase.resetChatSettings');
@@ -1101,9 +1076,7 @@ matchWholeWord: ${matchWholeWord},
 shareCrashLogsAndAnalytics: ${shareCrashLogsAndAnalytics},
 fullScreen: ${fullScreen},
 fullScreenChatOverlay: ${fullScreenChatOverlay},
-pinnedChannelIds: ${pinnedChannelIds},
-textControllerText: ${textControllerText},
-textControllerTextIsEmpty: ${textControllerTextIsEmpty}
+pinnedChannelIds: ${pinnedChannelIds}
     ''';
   }
 }

--- a/lib/screens/settings/stores/settings_store.g.dart
+++ b/lib/screens/settings/stores/settings_store.g.dart
@@ -64,10 +64,10 @@ SettingsStore _$SettingsStoreFromJson(Map<String, dynamic> json) =>
       ..showFFZBadges = json['showFFZBadges'] as bool? ?? true
       ..showRecentMessages = json['showRecentMessages'] as bool? ?? false
       ..darkenRecentMessages = json['darkenRecentMessages'] as bool? ?? true
-      ..mutedWords = json['mutedWords'] == null
-          ? _SettingsStoreBase.getDefaultMutedWords()
-          : const ObservableMutedWordsListConverter()
-              .fromJson(json['mutedWords'] as List)
+      ..mutedWords = (json['mutedWords'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          []
       ..matchWholeWord = json['matchWholeWord'] as bool? ?? true
       ..shareCrashLogsAndAnalytics =
           json['shareCrashLogsAndAnalytics'] as bool? ?? true
@@ -124,8 +124,7 @@ Map<String, dynamic> _$SettingsStoreToJson(SettingsStore instance) =>
       'showFFZBadges': instance.showFFZBadges,
       'showRecentMessages': instance.showRecentMessages,
       'darkenRecentMessages': instance.darkenRecentMessages,
-      'mutedWords':
-          const ObservableMutedWordsListConverter().toJson(instance.mutedWords),
+      'mutedWords': instance.mutedWords,
       'matchWholeWord': instance.matchWholeWord,
       'shareCrashLogsAndAnalytics': instance.shareCrashLogsAndAnalytics,
       'fullScreen': instance.fullScreen,
@@ -862,13 +861,13 @@ mixin _$SettingsStore on _SettingsStoreBase, Store {
       Atom(name: '_SettingsStoreBase.mutedWords', context: context);
 
   @override
-  ObservableList<String> get mutedWords {
+  List<String> get mutedWords {
     _$mutedWordsAtom.reportRead();
     return super.mutedWords;
   }
 
   @override
-  set mutedWords(ObservableList<String> value) {
+  set mutedWords(List<String> value) {
     _$mutedWordsAtom.reportWrite(value, super.mutedWords, () {
       super.mutedWords = value;
     });

--- a/lib/screens/settings/widgets/settings_muted_words.dart
+++ b/lib/screens/settings/widgets/settings_muted_words.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:frosty/screens/settings/stores/settings_store.dart';
 import 'package:frosty/widgets/alert_message.dart';
-import 'package:mobx/mobx.dart';
 
 class SettingsMutedWords extends StatefulWidget {
   final SettingsStore settingsStore;

--- a/lib/screens/settings/widgets/settings_muted_words.dart
+++ b/lib/screens/settings/widgets/settings_muted_words.dart
@@ -2,10 +2,37 @@ import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:frosty/screens/settings/stores/settings_store.dart';
 import 'package:frosty/widgets/alert_message.dart';
+import 'package:mobx/mobx.dart';
 
-class SettingsMutedWords extends StatelessWidget {
+class SettingsMutedWords extends StatefulWidget {
   final SettingsStore settingsStore;
   const SettingsMutedWords({super.key, required this.settingsStore});
+
+  @override
+  State<SettingsMutedWords> createState() => _SettingsMutedWordsState();
+}
+
+class _SettingsMutedWordsState extends State<SettingsMutedWords> {
+  late final SettingsStore settingsStore;
+  final TextEditingController textController = TextEditingController();
+  final FocusNode textFieldFocusNode = FocusNode();
+
+  @override
+  void initState() {
+    settingsStore = widget.settingsStore;
+    super.initState();
+  }
+
+  void addMutedWord(String text) {
+    settingsStore.mutedWords.add(text);
+
+    textController.clear();
+    textFieldFocusNode.unfocus();
+  }
+
+  void removeMutedWord(int index) {
+    settingsStore.mutedWords.removeAt(index);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -24,36 +51,32 @@ class SettingsMutedWords extends StatelessWidget {
                   Padding(
                     padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
                     child: TextField(
-                      controller: settingsStore.textController,
-                      focusNode: settingsStore.textFieldFocusNode,
+                      controller: textController,
+                      focusNode: textFieldFocusNode,
                       onChanged: (value) {
-                        settingsStore.textController.text = value;
+                        textController.text = value;
                       },
                       onSubmitted: (value) {
-                        settingsStore.addMutedWord(value);
+                        addMutedWord(value);
                       },
                       autocorrect: false,
                       decoration: InputDecoration(
                         hintText: 'Enter keywords to mute',
-                        suffixIcon: settingsStore.textControllerTextIsEmpty
-                            ? IconButton(
-                                tooltip:
-                                    settingsStore.textController.text.isEmpty
-                                        ? 'Cancel'
-                                        : 'Add keyword',
-                                onPressed: () {
-                                  if (settingsStore
-                                      .textController.text.isEmpty) {
-                                    settingsStore.textFieldFocusNode.unfocus();
-                                  } else {
-                                    settingsStore.addMutedWord(
-                                      settingsStore.textController.text,
-                                    );
-                                  }
-                                },
-                                icon: const Icon(Icons.check),
-                              )
-                            : null,
+                        suffixIcon: IconButton(
+                          tooltip: textController.text.isEmpty
+                              ? 'Cancel'
+                              : 'Add keyword',
+                          onPressed: () {
+                            if (textController.text.isEmpty) {
+                              textFieldFocusNode.unfocus();
+                            } else {
+                              addMutedWord(
+                                textController.text,
+                              );
+                            }
+                          },
+                          icon: const Icon(Icons.check),
+                        ),
                       ),
                     ),
                   ),
@@ -90,7 +113,7 @@ class SettingsMutedWords extends StatelessWidget {
                                     ),
                                     TextButton(
                                       onPressed: () {
-                                        settingsStore.removeMutedWord(index);
+                                        removeMutedWord(index);
                                         Navigator.of(context).pop();
                                       },
                                       child: const Text('Delete'),

--- a/lib/screens/settings/widgets/settings_muted_words.dart
+++ b/lib/screens/settings/widgets/settings_muted_words.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
+import 'package:frosty/screens/settings/stores/settings_store.dart';
+import 'package:frosty/widgets/alert_message.dart';
+
+class SettingsMutedWords extends StatelessWidget {
+  final SettingsStore settingsStore;
+  const SettingsMutedWords({super.key, required this.settingsStore});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      trailing: const Icon(Icons.edit),
+      title: const Text('Muted keywords'),
+      onTap: () => showModalBottomSheet(
+        isScrollControlled: true,
+        context: context,
+        builder: (context) => SizedBox(
+          height: MediaQuery.of(context).size.height * 0.8,
+          child: Observer(
+            builder: (context) {
+              return Column(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
+                    child: TextField(
+                      controller: settingsStore.textController,
+                      focusNode: settingsStore.textFieldFocusNode,
+                      onChanged: (value) {
+                        settingsStore.textController.text = value;
+                      },
+                      onSubmitted: (value) {
+                        settingsStore.addMutedWord(value);
+                      },
+                      autocorrect: false,
+                      decoration: InputDecoration(
+                        hintText: 'Enter keywords to mute',
+                        suffixIcon: settingsStore.textControllerTextIsEmpty
+                            ? IconButton(
+                                tooltip:
+                                    settingsStore.textController.text.isEmpty
+                                        ? 'Cancel'
+                                        : 'Add keyword',
+                                onPressed: () {
+                                  if (settingsStore
+                                      .textController.text.isEmpty) {
+                                    settingsStore.textFieldFocusNode.unfocus();
+                                  } else {
+                                    settingsStore.addMutedWord(
+                                      settingsStore.textController.text,
+                                    );
+                                  }
+                                },
+                                icon: const Icon(Icons.check),
+                              )
+                            : null,
+                      ),
+                    ),
+                  ),
+                  if (settingsStore.mutedWords.isEmpty)
+                    const Expanded(
+                      child: AlertMessage(
+                        message: 'No muted keywords',
+                      ),
+                    ),
+                  Expanded(
+                    child: ListView.builder(
+                      itemCount: settingsStore.mutedWords.length,
+                      itemBuilder: (context, index) {
+                        return ListTile(
+                          title:
+                              Text(settingsStore.mutedWords.elementAt(index)),
+                          trailing: IconButton(
+                            icon: const Icon(Icons.delete),
+                            onPressed: () {
+                              // show confirmation dialog before deleting a keyword
+                              showDialog(
+                                context: context,
+                                builder: (context) => AlertDialog(
+                                  title: const Text('Delete keyword'),
+                                  content: const Text(
+                                    'Are you sure you want to delete this keyword?',
+                                  ),
+                                  actions: [
+                                    TextButton(
+                                      onPressed: () {
+                                        Navigator.of(context).pop();
+                                      },
+                                      child: const Text('Cancel'),
+                                    ),
+                                    TextButton(
+                                      onPressed: () {
+                                        settingsStore.removeMutedWord(index);
+                                        Navigator.of(context).pop();
+                                      },
+                                      child: const Text('Delete'),
+                                    ),
+                                  ],
+                                ),
+                              );
+                            },
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/settings/widgets/settings_muted_words.dart
+++ b/lib/screens/settings/widgets/settings_muted_words.dart
@@ -24,14 +24,19 @@ class _SettingsMutedWordsState extends State<SettingsMutedWords> {
   }
 
   void addMutedWord(String text) {
-    settingsStore.mutedWords.add(text);
+    settingsStore.mutedWords = [
+      ...settingsStore.mutedWords,
+      text,
+    ];
 
     textController.clear();
     textFieldFocusNode.unfocus();
   }
 
   void removeMutedWord(int index) {
-    settingsStore.mutedWords.removeAt(index);
+    settingsStore.mutedWords = [
+      ...settingsStore.mutedWords..removeAt(index),
+    ];
   }
 
   @override


### PR DESCRIPTION
This PR adds the ability for users to mute specific keywords in the chat.
It adds a section in the chat settings. Besides the bottom sheet with a text field, there is a switch that makes the app only match whole words instead of words containing the keyword (for example, if someone wants to mute "W"s but doesn't want words with "w" to be filtered). 

Related to issue #400 

https://github.com/user-attachments/assets/b067f4ed-f4d4-4ff3-b15f-dfb8cadf99de

