### PR TITLE
Further improve initial playback stability

### DIFF
--- a/lib/screens/channel/video/video_store.dart
+++ b/lib/screens/channel/video/video_store.dart
@@ -363,6 +363,10 @@ abstract class VideoStoreBase with Store {
               VideoPlaying.postMessage("video playing");
               videoElement.textTracks[0].mode = "hidden";
             });
+            if (!videoElement.paused) {
+              VideoPlaying.postMessage("video playing");
+              videoElement.textTracks[0].mode = "hidden";
+            }
           });
         ''');
         if (settingsStore.showOverlay) {


### PR DESCRIPTION
Continues https://github.com/tommyxchow/frosty/pull/411. Looks like this PR didn't fully fix the issue, as shown in the following screenshot.

![Screenshot_20241119_190718](https://github.com/user-attachments/assets/17cb02c7-d88e-4bf2-9f24-b7a4dd567407)

The player is stuck in the paused state. The latency stat is showing though, which suggests the promise queue is working.

This PR adds a `if (!videoElement.paused)` check, because subscribing to the `playing` event when the video is already playing doesn't emit the event.

