### PR TITLE
fix missing emotes on channels that don't have 7tv enabled

### DIFF
--- a/lib/screens/channel/chat/stores/chat_store.dart
+++ b/lib/screens/channel/chat/stores/chat_store.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:frosty/apis/twitch_api.dart';
+import 'package:frosty/models/badges.dart';
 import 'package:frosty/models/emotes.dart';
 import 'package:frosty/models/events.dart';
 import 'package:frosty/models/irc.dart';
@@ -435,7 +436,7 @@ abstract class ChatStoreBase with Store {
         },
         onBadgeError: (error) {
           debugPrint(error.toString());
-          return <Badge>[];
+          return <ChatBadge>[];
         },
         showTwitchEmotes: settings.showTwitchEmotes,
         showTwitchBadges: settings.showTwitchBadges,


### PR DESCRIPTION
In a previous commit, the `catchError` in the 7TV emotes future was accidently changed to use the `onBadgeError` function, causing a type error to throw and making the rest of the emote futures to cancel/end early. When a channel doesn't have any 7TV emotes, the future will fail and call the error handler by default.

Fixed by reverting the error handler function.

Fixes #425 