### PR TITLE
fix some channels missing 7tv emotes

### DIFF
--- a/lib/apis/seventv_api.dart
+++ b/lib/apis/seventv_api.dart
@@ -42,6 +42,7 @@ class SevenTVApi {
         emoteSetId,
         emotes
             .map((emote) => Emote.from7TV(emote, EmoteType.sevenTVChannel))
+            .where((emote) => emote.url.isNotEmpty)
             .toList()
       );
     } else {

--- a/lib/models/emotes.dart
+++ b/lib/models/emotes.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:frosty/constants.dart';
 import 'package:json_annotation/json_annotation.dart';
 
@@ -269,8 +270,8 @@ class Emote {
 
     final url = emoteData.host.url;
 
-    // Flutter doesn't support AVIF yet.
-    final file = emoteData.host.files.lastWhere(
+    // TODO: Remove if/when Flutter natively supports AVIF.
+    final file = emoteData.host.files.lastWhereOrNull(
       (file) => file.format != 'AVIF',
     );
 
@@ -280,10 +281,10 @@ class Emote {
     return Emote(
       name: emote.name,
       realName: emote.name != emoteData.name ? emoteData.name : null,
-      width: emoteData.host.files.first.width,
-      height: emoteData.host.files.first.height,
+      width: emoteData.host.files.firstOrNull?.width,
+      height: emoteData.host.files.firstOrNull?.height,
       zeroWidth: isZeroWidth,
-      url: 'https:$url/${file.name}',
+      url: file != null ? 'https:$url/${file.name}' : '',
       type: type,
       ownerDisplayName: emoteData.owner?.displayName,
       ownerUsername: emoteData.owner?.username,

--- a/lib/models/emotes.dart
+++ b/lib/models/emotes.dart
@@ -127,7 +127,7 @@ class EmoteFFZ {
 class Emote7TV {
   final String id;
   final String name;
-  final Emote7TVData? data;
+  final Emote7TVData data;
 
   const Emote7TV(
     this.id,
@@ -267,7 +267,7 @@ class Emote {
   factory Emote.from7TV(Emote7TV emote, EmoteType type) {
     final emoteData = emote.data;
 
-    final url = emoteData!.host.url;
+    final url = emoteData.host.url;
 
     // Flutter doesn't support AVIF yet.
     final file = emoteData.host.files.lastWhere(

--- a/lib/models/emotes.g.dart
+++ b/lib/models/emotes.g.dart
@@ -63,9 +63,7 @@ EmoteFFZ _$EmoteFFZFromJson(Map<String, dynamic> json) => EmoteFFZ(
 Emote7TV _$Emote7TVFromJson(Map<String, dynamic> json) => Emote7TV(
       json['id'] as String,
       json['name'] as String,
-      json['data'] == null
-          ? null
-          : Emote7TVData.fromJson(json['data'] as Map<String, dynamic>),
+      Emote7TVData.fromJson(json['data'] as Map<String, dynamic>),
     );
 
 Owner7TV _$Owner7TVFromJson(Map<String, dynamic> json) => Owner7TV(

--- a/lib/models/events.g.dart
+++ b/lib/models/events.g.dart
@@ -12,21 +12,12 @@ SevenTVEvent _$SevenTVEventFromJson(Map<String, dynamic> json) => SevenTVEvent(
       d: SevenTVEventData.fromJson(json['d'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$SevenTVEventToJson(SevenTVEvent instance) {
-  final val = <String, dynamic>{
-    'op': instance.op,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('t', instance.t);
-  val['d'] = instance.d;
-  return val;
-}
+Map<String, dynamic> _$SevenTVEventToJson(SevenTVEvent instance) =>
+    <String, dynamic>{
+      'op': instance.op,
+      if (instance.t case final value?) 't': value,
+      'd': instance.d,
+    };
 
 SevenTVEventData _$SevenTVEventDataFromJson(Map<String, dynamic> json) =>
     SevenTVEventData(


### PR DESCRIPTION
Fixes #440 #422

This PR fixes a case where one or more 7TV emotes that are still processing cause the emote processing/parsing to fail, throwing a `Bad state: No element` error and returning no 7TV emotes. Was happening on the AlveusSanctuary  and Yogscast channels.

Example in the AlveusSanctuary channel:
- 7TV data: https://7tv.io/v3/users/twitch/636587384):
- One of the emotes (JSON below) an empty array in the `host.files`, causing the error to throw.
- Going to the emote on 7TV's site, the emote is still processing (https://7tv.app/emotes/01JS0D2GFVZHRZFV5DM4E7HZBY)
- Fix was to use the `OrNull` versions for the `.first` and `.last` getters
```json
{
  "id": "01JS0D2GFVZHRZFV5DM4E7HZBY",
  "name": "Bowlgegorge",
  "flags": 0,
  "timestamp": 1744844177915,
  "actor_id": "01GBJ40WG80003QC42CBXPR1QJ",
  "data": {
    "id": "01JS0D2GFVZHRZFV5DM4E7HZBY",
    "name": "Bowlgegorge",
    "flags": 0,
    "tags": [
      "frog",
      "alveussanctuary",
      "alveus"
    ],
    "lifecycle": 0,
    "state": [],
    "listed": false,
    "animated": false,
    "owner": {
      "id": "01JS0CXFQXXRJ4G6W9CYP3BKPV",
      "username": "uhhophelia",
      "display_name": "UhhOphelia",
      "avatar_url": "https://static-cdn.jtvnw.net/jtv_user_pictures/89e1bde0-7769-469d-9743-f64d2934b507-profile_image-300x300.jpeg",
      "style": {},
      "role_ids": [
        "01G68MMQFR0007J6GNM9E2M0TM"
      ],
      "connections": [
        {
          "id": "1073757257",
          "platform": "TWITCH",
          "username": "uhhophelia",
          "display_name": "UhhOphelia",
          "linked_at": 1744844013309,
          "emote_capacity": 1000,
          "emote_set_id": null
        }
      ]
    },
    "host": {
      "url": "",
      "files": []
    }
  },
  "origin_id": null
}
```