### PR TITLE
Fix orphaned cache cleanup

### DIFF
--- a/lib/cache_manager.dart
+++ b/lib/cache_manager.dart
@@ -23,14 +23,15 @@ class CustomCacheManager {
       return;
     }
 
-    final allFiles = cacheDir.listSync(recursive: true).toList();
+    final allFiles =
+        cacheDir.listSync(recursive: true).whereType<File>().toList();
 
     await _repo.open();
     final cachedObjects = await _repo.getAllObjects();
     final dbFiles = cachedObjects.map((e) => e.relativePath).toSet();
 
     final orphanedFiles = allFiles.where((file) {
-      final relativePath = file.path.split('$key/').last;
+      final relativePath = file.path.replaceFirst('${cacheDir.path}/', '');
       return !dbFiles.contains(relativePath);
     }).toList();
 


### PR DESCRIPTION
## Summary
- handle only files when purging cache
- compute relative paths correctly before deletion

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de397f224832c902db542c8e6d435