### PR TITLE
For #383: Support Twitch channel links

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -36,6 +36,15 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+                <intent-filter android:autoVerify="true">
+                    <action android:name="android.intent.action.VIEW" />
+                    <category android:name="android.intent.category.DEFAULT" />
+                    <category android:name="android.intent.category.BROWSABLE" />
+                    <data android:scheme="https"/>
+                    <data android:host="twitch.tv" />
+                    <data android:host="www.twitch.tv" />
+                    <data android:host="m.twitch.tv" />
+                </intent-filter>
         </activity>
         <meta-data
             android:name="io.flutter.embedding.android.EnableImpeller"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,8 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:advanced_in_app_review/advanced_in_app_review.dart';
+import 'package:app_links/app_links.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/foundation.dart';
@@ -13,16 +15,19 @@ import 'package:frosty/apis/seventv_api.dart';
 import 'package:frosty/apis/twitch_api.dart';
 import 'package:frosty/cache_manager.dart';
 import 'package:frosty/firebase_options.dart';
+import 'package:frosty/screens/channel/channel.dart';
 import 'package:frosty/screens/home/home.dart';
 import 'package:frosty/screens/onboarding/onboarding_intro.dart';
 import 'package:frosty/screens/settings/stores/auth_store.dart';
 import 'package:frosty/screens/settings/stores/settings_store.dart';
 import 'package:frosty/theme.dart';
 import 'package:frosty/utils.dart';
+import 'package:frosty/widgets/alert_message.dart';
 import 'package:http/http.dart';
 import 'package:mobx/mobx.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -110,6 +115,9 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
+  final AppLinks _appLinks = AppLinks();
+  StreamSubscription<Uri>? _linkSubscription;
+
   @override
   void initState() {
     super.initState();
@@ -120,6 +128,8 @@ class _MyAppState extends State<MyApp> {
         .setMinLaunchTimes(5)
         .setMinSecondsBeforeShowDialog(3)
         .monitor();
+
+    _initDeepLinks();
   }
 
   @override
@@ -127,8 +137,8 @@ class _MyAppState extends State<MyApp> {
     return Observer(
       builder: (context) {
         final settingsStore = context.read<SettingsStore>();
-        final themes =
-            FrostyThemes(colorSchemeSeed: Color(settingsStore.accentColor));
+        final themes = 
+		    FrostyThemes(colorSchemeSeed: Color(settingsStore.accentColor));
 
         return Provider<FrostyThemes>(
           create: (_) => themes,
@@ -147,5 +157,87 @@ class _MyAppState extends State<MyApp> {
         );
       },
     );
+  }
+
+  Future<void> _initDeepLinks() async {
+    try {
+      // Handle links when app is already open
+      _linkSubscription = _appLinks.uriLinkStream.listen((uri) {
+        handleDeepLink(uri);
+      });
+
+      // Handle the initial link if app was opened from a link
+      final initialLink = await _appLinks.getInitialLink();
+      if (initialLink != null) {
+        handleDeepLink(initialLink);
+      }
+    } catch (e) {
+      debugPrint('Failed to initialize deep links: $e');
+    }
+  }
+
+  Future<void> handleDeepLink(Uri uri) async {
+    final failureSnackbar = SnackBar(
+      content: AlertMessage(
+        message: 'Unable to navigate to \'$uri\'',
+        centered: false,
+        trailingIcon: Icons.open_in_browser_rounded,
+        // Fallback, allow user to open URL outside app
+        onTrailingIconPressed: () async {
+          await launchUrl(
+            uri,
+            mode: LaunchMode.inAppWebView, // Force browser
+          );
+        },
+      ),
+    );
+
+    // Handle channel links
+    if (uri.pathSegments.isNotEmpty) {
+      final channelName = uri.pathSegments.first;
+
+      try {
+        final twitchApi = context.read<TwitchApi>();
+        final authStore = context.read<AuthStore>();
+
+        final user = await twitchApi.getUser(
+          userLogin: channelName,
+          headers: authStore.headersTwitch,
+        );
+
+        final route = MaterialPageRoute(
+          builder: (context) => VideoChat(
+            userId: user.id,
+            userName: user.displayName,
+            userLogin: user.login,
+          ),
+        );
+
+        if (navigatorKey.currentState == null) return;
+
+        WidgetsBinding.instance.addPostFrameCallback(
+          (_) => navigatorKey.currentState?.push(route),
+        );
+      } catch (e) {
+        // If we get here, there was most likely an error with the Twitch API call and/or this isn't really a channel link
+        debugPrint('Failed to open link $uri due to error: $e');
+
+        if (navigatorKey.currentContext == null) return;
+        ScaffoldMessenger.of(navigatorKey.currentContext!)
+            .showSnackBar(failureSnackbar);
+      }
+    }
+    // TODO: Here we can implement handlers for other types of links
+    else {
+      // If we get here, it's a link format that we're unable to handle
+      if (navigatorKey.currentContext == null) return;
+      ScaffoldMessenger.of(navigatorKey.currentContext!).showSnackBar(failureSnackbar);
+    }
+  }
+
+  @override
+  void dispose() {
+    _linkSubscription?.cancel();
+    super.dispose();
   }
 }

--- a/lib/widgets/alert_message.dart
+++ b/lib/widgets/alert_message.dart
@@ -5,12 +5,16 @@ class AlertMessage extends StatelessWidget {
   final String message;
   final Color? color;
   final bool centered;
+  final IconData? trailingIcon;
+  final VoidCallback? onTrailingIconPressed;
 
   const AlertMessage({
     super.key,
     required this.message,
     this.centered = true,
     this.color,
+    this.trailingIcon,
+    this.onTrailingIconPressed,
   });
 
   @override
@@ -35,6 +39,19 @@ class AlertMessage extends StatelessWidget {
             ),
           ),
         ),
+        if (trailingIcon != null) ...[
+          const SizedBox(width: 8),
+          IconButton(
+            icon: Icon(
+              trailingIcon,
+              color: color ?? defaultColor,
+            ),
+            onPressed: onTrailingIconPressed,
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(),
+            iconSize: 20,
+          ),
+        ],
       ],
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  app_links:
+    dependency: "direct main"
+    description:
+      name: app_links
+      sha256: "5f88447519add627fe1cbcab4fd1da3d4fed15b9baf29f28b22535c95ecee3e8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  app_links_linux:
+    dependency: transitive
+    description:
+      name: app_links_linux
+      sha256: f5f7173a78609f3dfd4c2ff2c95bd559ab43c80a87dc6a095921d96c05688c81
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  app_links_platform_interface:
+    dependency: transitive
+    description:
+      name: app_links_platform_interface
+      sha256: "05f5379577c513b534a29ddea68176a4d4802c46180ee8e2e966257158772a3f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
+  app_links_web:
+    dependency: transitive
+    description:
+      name: app_links_web
+      sha256: af060ed76183f9e2b87510a9480e56a5352b6c249778d07bd2c95fc35632a555
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   archive:
     dependency: transitive
     description:
@@ -544,6 +576,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  gtk:
+    dependency: transitive
+    description:
+      name: gtk
+      sha256: e8ce9ca4b1df106e4d72dad201d345ea1a036cc12c360f1a7d5a758f78ffa42c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   html:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,6 +68,7 @@ dependencies:
     flutter_markdown: ^0.7.3+1
     flutter_colorpicker: ^1.1.0
     path_provider: ^2.1.5
+    app_links: ^6.4.1
 
 dev_dependencies:
     flutter_test:


### PR DESCRIPTION
For #383: This PR adds the ability to handle Twitch channel links in Frosty and open the corresponding channel page.

Notes
- This should work whether Frosty is already open or not
- Works whether or not the streamer is live

**Important Caveats**
- I only added the link registration for Android, since that's the platform I have available to test with. I believe it is possible to do something similar for iOS, but they may be more strict in terms of requiring you to prove that you "own" the domain. Whereas on Android, even if you don't own the domain, users can optionally choose to have your app handle those links (see the demo video).
- I only added support for channel links. I'm sure there are plenty of other links that Frosty could handle by navigating to other appropriate pages. But I figured channels would be the biggest chunk to knock out first. If we do see an unsupported link, there is an option to open the link in the system browser.

### Demo

https://github.com/user-attachments/assets/a894cdbd-9e92-4678-8d61-81f10e87bb38
