### PR TITLE
Add option to disable emote animations

### DIFF
--- a/lib/models/emotes.g.dart
+++ b/lib/models/emotes.g.dart
@@ -85,6 +85,7 @@ Emote7TVHost _$Emote7TVHostFromJson(Map<String, dynamic> json) => Emote7TVHost(
 
 Emote7TVFile _$Emote7TVFileFromJson(Map<String, dynamic> json) => Emote7TVFile(
   json['name'] as String,
+  json['static_name'] as String?,
   (json['width'] as num).toInt(),
   (json['height'] as num).toInt(),
   json['format'] as String,
@@ -97,6 +98,7 @@ Emote _$EmoteFromJson(Map<String, dynamic> json) => Emote(
   height: (json['height'] as num?)?.toInt(),
   zeroWidth: json['zeroWidth'] as bool,
   url: json['url'] as String,
+  staticUrl: json['staticUrl'] as String?,
   type: $enumDecode(_$EmoteTypeEnumMap, json['type']),
   ownerDisplayName: json['ownerDisplayName'] as String?,
   ownerUsername: json['ownerUsername'] as String?,
@@ -110,6 +112,7 @@ Map<String, dynamic> _$EmoteToJson(Emote instance) => <String, dynamic>{
   'height': instance.height,
   'zeroWidth': instance.zeroWidth,
   'url': instance.url,
+  'staticUrl': instance.staticUrl,
   'type': _$EmoteTypeEnumMap[instance.type]!,
   'ownerDisplayName': instance.ownerDisplayName,
   'ownerUsername': instance.ownerUsername,

--- a/lib/models/irc.dart
+++ b/lib/models/irc.dart
@@ -442,8 +442,9 @@ class IRCMessage {
     bool launchExternal,
     TextStyle? textStyle,
     void Function(String)? onTapPingedUser,
-    void Function()? onTapDeletedMessage,
-  ) {
+    void Function()? onTapDeletedMessage, {
+    bool disableEmoteAnimations = false,
+  }) {
     if (!showMessage) {
       span.add(
         TextSpan(
@@ -493,6 +494,7 @@ class IRCMessage {
               emoteScale,
               textStyle,
               launchExternal,
+              disableEmoteAnimations: disableEmoteAnimations,
             );
           } else {
             localSpan.add(
@@ -504,6 +506,7 @@ class IRCMessage {
                     : emoteSize,
                 width: emote.width != null ? emote.width! * emoteScale : null,
                 launchExternal: launchExternal,
+                disableEmoteAnimations: disableEmoteAnimations,
               ),
             );
             localSpan.add(const TextSpan(text: ' '));
@@ -550,8 +553,9 @@ class IRCMessage {
     double emoteSize,
     double emoteScale,
     TextStyle? textStyle,
-    bool launchExternal,
-  ) {
+    bool launchExternal, {
+    bool disableEmoteAnimations = false,
+  }) {
     final emoteStack = <Emote>[];
     var index = startIndex;
 
@@ -578,7 +582,9 @@ class IRCMessage {
         ),
       ...emoteStack.reversed.map(
         (emote) => FrostyCachedNetworkImage(
-          imageUrl: emote.url,
+          imageUrl: emote.getDisplayUrl(
+            disableAnimations: disableEmoteAnimations,
+          ),
           height: emote.height != null ? emote.height! * emoteScale : emoteSize,
           width: emote.width != null ? emote.width! * emoteScale : emoteSize,
           useFade: false,
@@ -602,12 +608,18 @@ class IRCMessage {
                 if (nextWordIsEmoji)
                   Text(emoji, style: textStyle?.copyWith(fontSize: 40)),
                 ...emoteStack.reversed.map(
-                  (emote) =>
-                      FrostyCachedNetworkImage(imageUrl: emote.url, width: 56),
+                  (emote) => FrostyCachedNetworkImage(
+                    imageUrl: emote.getDisplayUrl(
+                      disableAnimations: disableEmoteAnimations,
+                    ),
+                    width: 56,
+                  ),
                 ),
               ],
             ),
-            url: emoteStack.last.url,
+            url: emoteStack.last.getDisplayUrl(
+              disableAnimations: disableEmoteAnimations,
+            ),
             title: nextWordIsEmoji
                 ? emoji
                 : '${emoteStack.last.name} (${emoteStack.last.type})',
@@ -657,6 +669,7 @@ class IRCMessage {
     Map<String, UserTwitch>? channelIdToUserTwitch,
     TimestampType timestamp = TimestampType.disabled,
     String? currentChannelId,
+    bool disableEmoteAnimations = false,
   }) {
     final emoteToObject = assetsStore.emoteToObject;
     final badgeSize = defaultBadgeSize * badgeScale;
@@ -702,6 +715,7 @@ class IRCMessage {
       textStyle,
       onTapPingedUser,
       onTapDeletedMessage,
+      disableEmoteAnimations: disableEmoteAnimations,
     );
 
     return span;
@@ -786,6 +800,7 @@ class IRCMessage {
     required double height,
     required double? width,
     required bool launchExternal,
+    bool disableEmoteAnimations = false,
   }) {
     return WidgetSpan(
       alignment: PlaceholderAlignment.middle,
@@ -794,9 +809,12 @@ class IRCMessage {
           context,
           emote: emote,
           launchExternal: launchExternal,
+          disableEmoteAnimations: disableEmoteAnimations,
         ),
         child: FrostyCachedNetworkImage(
-          imageUrl: emote.url,
+          imageUrl: emote.getDisplayUrl(
+            disableAnimations: disableEmoteAnimations,
+          ),
           height: height,
           width: width,
           useFade: false,
@@ -848,11 +866,15 @@ class IRCMessage {
     BuildContext context, {
     required Emote emote,
     required bool launchExternal,
+    bool disableEmoteAnimations = false,
   }) {
+    final displayUrl = emote.getDisplayUrl(
+      disableAnimations: disableEmoteAnimations,
+    );
     _showAssetDetailsBottomSheet(
       context,
-      leading: FrostyCachedNetworkImage(imageUrl: emote.url, width: 56),
-      url: emote.url,
+      leading: FrostyCachedNetworkImage(imageUrl: displayUrl, width: 56),
+      url: displayUrl,
       title: emote.realName != null
           ? '${emote.name} (${emote.realName})'
           : emote.name,

--- a/lib/screens/channel/chat/details/chat_details.dart
+++ b/lib/screens/channel/chat/details/chat_details.dart
@@ -537,6 +537,8 @@ class _ChatColorPickerModalState extends State<_ChatColorPickerModal> {
           badgeScale: widget.chatStore.settings.badgeScale,
           launchExternal: false, // Disable launching for preview
           style: DefaultTextStyle.of(context).style,
+          disableEmoteAnimations:
+              widget.chatStore.settings.disableEmoteAnimations,
         ),
       ),
     );

--- a/lib/screens/channel/chat/emote_menu/emote_menu_section.dart
+++ b/lib/screens/channel/chat/emote_menu/emote_menu_section.dart
@@ -52,13 +52,18 @@ class _EmoteMenuSectionState extends State<EmoteMenuSection>
               context,
               emote: widget.emotes[index],
               launchExternal: widget.chatStore.settings.launchUrlExternal,
+              disableEmoteAnimations:
+                  widget.chatStore.settings.disableEmoteAnimations,
             );
           },
           child: Padding(
             padding: const EdgeInsets.all(5.0),
             child: Center(
               child: FrostyCachedNetworkImage(
-                imageUrl: widget.emotes[index].url,
+                imageUrl: widget.emotes[index].getDisplayUrl(
+                  disableAnimations:
+                      widget.chatStore.settings.disableEmoteAnimations,
+                ),
                 height:
                     widget.emotes[index].height?.toDouble() ?? defaultEmoteSize,
                 width: widget.emotes[index].width?.toDouble(),

--- a/lib/screens/channel/chat/emote_menu/recent_emotes_panel.dart
+++ b/lib/screens/channel/chat/emote_menu/recent_emotes_panel.dart
@@ -87,15 +87,22 @@ class RecentEmotesPanel extends StatelessWidget {
                           context,
                           emote: emote,
                           launchExternal: chatStore.settings.launchUrlExternal,
+                          disableEmoteAnimations:
+                              chatStore.settings.disableEmoteAnimations,
                         );
                       },
                       child: Padding(
                         padding: const EdgeInsets.all(8),
                         child: Center(
                           child: FrostyCachedNetworkImage(
-                            imageUrl: matchingEmotes.isNotEmpty
-                                ? matchingEmotes.first.url
-                                : emote.url,
+                            imageUrl: (matchingEmotes.isNotEmpty
+                                    ? matchingEmotes.first
+                                    : emote)
+                                .getDisplayUrl(
+                                  disableAnimations: chatStore
+                                      .settings
+                                      .disableEmoteAnimations,
+                                ),
                             color: matchingEmotes.isNotEmpty
                                 ? null
                                 : const Color.fromRGBO(255, 255, 255, 0.5),

--- a/lib/screens/channel/chat/widgets/chat_bottom_bar.dart
+++ b/lib/screens/channel/chat/widgets/chat_bottom_bar.dart
@@ -106,6 +106,9 @@ class ChatBottomBar extends StatelessWidget {
                                         chatStore.settings.launchUrlExternal,
                                     timestamp: chatStore.settings.timestampType,
                                     currentChannelId: chatStore.channelId,
+                                    disableEmoteAnimations: chatStore
+                                        .settings
+                                        .disableEmoteAnimations,
                                   ),
                             ),
                             maxLines: 1,
@@ -152,13 +155,18 @@ class ChatBottomBar extends StatelessWidget {
                           context,
                           emote: matchingEmotes[index],
                           launchExternal: chatStore.settings.launchUrlExternal,
+                          disableEmoteAnimations:
+                              chatStore.settings.disableEmoteAnimations,
                         );
                       },
                       child: Padding(
                         padding: const EdgeInsets.symmetric(horizontal: 8),
                         child: Center(
                           child: FrostyCachedNetworkImage(
-                            imageUrl: matchingEmotes[index].url,
+                            imageUrl: matchingEmotes[index].getDisplayUrl(
+                              disableAnimations:
+                                  chatStore.settings.disableEmoteAnimations,
+                            ),
                             useFade: false,
                             height:
                                 matchingEmotes[index].height?.toDouble() ??
@@ -272,6 +280,8 @@ class ChatBottomBar extends StatelessWidget {
                                 emoteSize:
                                     chatStore.settings.emoteScale *
                                     defaultEmoteSize,
+                                disableEmoteAnimations:
+                                    chatStore.settings.disableEmoteAnimations,
                               ),
                               decoration: InputDecoration(
                                 prefixIcon:

--- a/lib/screens/channel/chat/widgets/chat_message.dart
+++ b/lib/screens/channel/chat/widgets/chat_message.dart
@@ -106,6 +106,8 @@ class ChatMessage extends StatelessWidget {
                   channelIdToUserTwitch:
                       chatStore.assetsStore.channelIdToUserTwitch,
                   currentChannelId: chatStore.channelId,
+                  disableEmoteAnimations:
+                      chatStore.settings.disableEmoteAnimations,
                 ),
                 style: defaultTextStyle,
               ),
@@ -203,6 +205,8 @@ class ChatMessage extends StatelessWidget {
                   channelIdToUserTwitch:
                       chatStore.assetsStore.channelIdToUserTwitch,
                   currentChannelId: chatStore.channelId,
+                  disableEmoteAnimations:
+                      chatStore.settings.disableEmoteAnimations,
                 ),
               ),
             );
@@ -355,6 +359,8 @@ class ChatMessage extends StatelessWidget {
                         channelIdToUserTwitch:
                             chatStore.assetsStore.channelIdToUserTwitch,
                         currentChannelId: chatStore.channelId,
+                        disableEmoteAnimations:
+                            chatStore.settings.disableEmoteAnimations,
                       ),
                     ),
                   ),
@@ -478,6 +484,8 @@ class ChatMessage extends StatelessWidget {
                           channelIdToUserTwitch:
                               chatStore.assetsStore.channelIdToUserTwitch,
                           currentChannelId: chatStore.channelId,
+                          disableEmoteAnimations:
+                              chatStore.settings.disableEmoteAnimations,
                         ),
                       ),
                     ),

--- a/lib/screens/settings/chat_settings.dart
+++ b/lib/screens/settings/chat_settings.dart
@@ -310,6 +310,13 @@ class _ChatSettingsState extends State<ChatSettings> {
             value: settingsStore.showFFZBadges,
             onChanged: (newValue) => settingsStore.showFFZBadges = newValue,
           ),
+          SettingsListSwitch(
+            title: 'Disable emote animations',
+            subtitle: const Text('Shows static versions of animated emotes.'),
+            value: settingsStore.disableEmoteAnimations,
+            onChanged: (newValue) =>
+                settingsStore.disableEmoteAnimations = newValue,
+          ),
           const SectionHeader('Recent messages'),
           SettingsListSwitch(
             title: 'Show historical recent messages',

--- a/lib/screens/settings/stores/settings_store.dart
+++ b/lib/screens/settings/stores/settings_store.dart
@@ -154,6 +154,7 @@ abstract class _SettingsStoreBase with Store {
   static const defaultShowBTTVBadges = true;
   static const defaultShowFFZEmotes = true;
   static const defaultShowFFZBadges = true;
+  static const defaultDisableEmoteAnimations = false;
 
   // Recent messages defaults
   static const defaultShowRecentMessages = false;
@@ -277,6 +278,10 @@ abstract class _SettingsStoreBase with Store {
   @observable
   var showFFZBadges = defaultShowFFZBadges;
 
+  @JsonKey(defaultValue: defaultDisableEmoteAnimations)
+  @observable
+  var disableEmoteAnimations = defaultDisableEmoteAnimations;
+
   // Recent messages
   @JsonKey(defaultValue: defaultShowRecentMessages)
   @observable
@@ -337,6 +342,7 @@ abstract class _SettingsStoreBase with Store {
     showBTTVBadges = defaultShowBTTVBadges;
     showFFZEmotes = defaultShowFFZEmotes;
     showFFZBadges = defaultShowFFZBadges;
+    disableEmoteAnimations = defaultDisableEmoteAnimations;
 
     showRecentMessages = defaultShowRecentMessages;
 

--- a/lib/screens/settings/stores/settings_store.g.dart
+++ b/lib/screens/settings/stores/settings_store.g.dart
@@ -66,6 +66,7 @@ SettingsStore _$SettingsStoreFromJson(
   ..showBTTVBadges = json['showBTTVBadges'] as bool? ?? true
   ..showFFZEmotes = json['showFFZEmotes'] as bool? ?? true
   ..showFFZBadges = json['showFFZBadges'] as bool? ?? true
+  ..disableEmoteAnimations = json['disableEmoteAnimations'] as bool? ?? false
   ..showRecentMessages = json['showRecentMessages'] as bool? ?? false
   ..persistChatTabs = json['persistChatTabs'] as bool? ?? true
   ..secondaryTabs =
@@ -129,6 +130,7 @@ Map<String, dynamic> _$SettingsStoreToJson(
   'showBTTVBadges': instance.showBTTVBadges,
   'showFFZEmotes': instance.showFFZEmotes,
   'showFFZBadges': instance.showFFZBadges,
+  'disableEmoteAnimations': instance.disableEmoteAnimations,
   'showRecentMessages': instance.showRecentMessages,
   'persistChatTabs': instance.persistChatTabs,
   'secondaryTabs': instance.secondaryTabs,
@@ -860,6 +862,28 @@ mixin _$SettingsStore on _SettingsStoreBase, Store {
     });
   }
 
+  late final _$disableEmoteAnimationsAtom = Atom(
+    name: '_SettingsStoreBase.disableEmoteAnimations',
+    context: context,
+  );
+
+  @override
+  bool get disableEmoteAnimations {
+    _$disableEmoteAnimationsAtom.reportRead();
+    return super.disableEmoteAnimations;
+  }
+
+  @override
+  set disableEmoteAnimations(bool value) {
+    _$disableEmoteAnimationsAtom.reportWrite(
+      value,
+      super.disableEmoteAnimations,
+      () {
+        super.disableEmoteAnimations = value;
+      },
+    );
+  }
+
   late final _$showRecentMessagesAtom = Atom(
     name: '_SettingsStoreBase.showRecentMessages',
     context: context,
@@ -1147,6 +1171,7 @@ showBTTVEmotes: ${showBTTVEmotes},
 showBTTVBadges: ${showBTTVBadges},
 showFFZEmotes: ${showFFZEmotes},
 showFFZBadges: ${showFFZBadges},
+disableEmoteAnimations: ${disableEmoteAnimations},
 showRecentMessages: ${showRecentMessages},
 persistChatTabs: ${persistChatTabs},
 secondaryTabs: ${secondaryTabs},

--- a/lib/widgets/chat_input/emote_text_span_builder.dart
+++ b/lib/widgets/chat_input/emote_text_span_builder.dart
@@ -18,10 +18,14 @@ class EmoteTextSpanBuilder extends SpecialTextSpanBuilder {
   /// The height to render emotes at.
   final double emoteSize;
 
+  /// Whether to disable animated emotes and show static versions.
+  final bool disableEmoteAnimations;
+
   EmoteTextSpanBuilder({
     required this.emoteToObject,
     required this.userEmoteToObject,
     required this.emoteSize,
+    this.disableEmoteAnimations = false,
   });
 
   @override
@@ -100,7 +104,9 @@ class EmoteTextSpanBuilder extends SpecialTextSpanBuilder {
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 1),
         child: FrostyCachedNetworkImage(
-          imageUrl: emote.url,
+          imageUrl: emote.getDisplayUrl(
+            disableAnimations: disableEmoteAnimations,
+          ),
           height: height,
           width: width,
           useFade: false,

--- a/test/models/emotes_test.dart
+++ b/test/models/emotes_test.dart
@@ -3,13 +3,8 @@ import 'package:frosty/models/emotes.dart';
 
 void main() {
   group('Emote.fromTwitch', () {
-    test('creates emote with correct URL', () {
-      final twitchEmote = EmoteTwitch(
-        '25',
-        'Kappa',
-        'bitstier',
-        null,
-      );
+    test('creates emote with default and static URLs', () {
+      final twitchEmote = EmoteTwitch('25', 'Kappa', 'bitstier', null);
 
       final emote = Emote.fromTwitch(twitchEmote, EmoteType.twitchGlobal);
 
@@ -17,18 +12,17 @@ void main() {
         emote.url,
         'https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/3.0',
       );
+      expect(
+        emote.staticUrl,
+        'https://static-cdn.jtvnw.net/emoticons/v2/25/static/dark/3.0',
+      );
       expect(emote.name, 'Kappa');
       expect(emote.type, EmoteType.twitchGlobal);
       expect(emote.zeroWidth, isFalse);
     });
 
     test('preserves owner ID when provided', () {
-      final twitchEmote = EmoteTwitch(
-        '12345',
-        'SubEmote',
-        'subscriptions',
-        '67890',
-      );
+      final twitchEmote = EmoteTwitch('12345', 'SubEmote', 'subscriptions', '67890');
 
       final emote = Emote.fromTwitch(twitchEmote, EmoteType.twitchSub);
 
@@ -229,14 +223,14 @@ void main() {
           Emote7TVHost(
             '//cdn.7tv.app/emote/7tvid123',
             [
-              Emote7TVFile('1x.webp', 32, 32, 'WEBP'),
-              Emote7TVFile('2x.webp', 64, 64, 'WEBP'),
-              Emote7TVFile('3x.webp', 96, 96, 'WEBP'),
-              Emote7TVFile('4x.webp', 128, 128, 'WEBP'),
-              Emote7TVFile('1x.avif', 32, 32, 'AVIF'),
-              Emote7TVFile('2x.avif', 64, 64, 'AVIF'),
-              Emote7TVFile('3x.avif', 96, 96, 'AVIF'),
-              Emote7TVFile('4x.avif', 128, 128, 'AVIF'),
+              Emote7TVFile('1x.webp', '1x_static.webp', 32, 32, 'WEBP'),
+              Emote7TVFile('2x.webp', '2x_static.webp', 64, 64, 'WEBP'),
+              Emote7TVFile('3x.webp', '3x_static.webp', 96, 96, 'WEBP'),
+              Emote7TVFile('4x.webp', '4x_static.webp', 128, 128, 'WEBP'),
+              Emote7TVFile('1x.avif', '1x_static.avif', 32, 32, 'AVIF'),
+              Emote7TVFile('2x.avif', '2x_static.avif', 64, 64, 'AVIF'),
+              Emote7TVFile('3x.avif', '3x_static.avif', 96, 96, 'AVIF'),
+              Emote7TVFile('4x.avif', '4x_static.avif', 128, 128, 'AVIF'),
             ],
           ),
         ),
@@ -261,7 +255,7 @@ void main() {
           null,
           Emote7TVHost(
             '//cdn.7tv.app/emote/zw123',
-            [Emote7TVFile('1x.webp', 32, 32, 'WEBP')],
+            [Emote7TVFile('1x.webp', '1x_static.webp', 32, 32, 'WEBP')],
           ),
         ),
       );
@@ -282,7 +276,7 @@ void main() {
           null,
           Emote7TVHost(
             '//cdn.7tv.app/emote/regular123',
-            [Emote7TVFile('1x.webp', 32, 32, 'WEBP')],
+            [Emote7TVFile('1x.webp', '1x_static.webp', 32, 32, 'WEBP')],
           ),
         ),
       );
@@ -303,7 +297,7 @@ void main() {
           null,
           Emote7TVHost(
             '//cdn.7tv.app/emote/alias123',
-            [Emote7TVFile('1x.webp', 32, 32, 'WEBP')],
+            [Emote7TVFile('1x.webp', '1x_static.webp', 32, 32, 'WEBP')],
           ),
         ),
       );
@@ -325,7 +319,7 @@ void main() {
           null,
           Emote7TVHost(
             '//cdn.7tv.app/emote/same123',
-            [Emote7TVFile('1x.webp', 32, 32, 'WEBP')],
+            [Emote7TVFile('1x.webp', '1x_static.webp', 32, 32, 'WEBP')],
           ),
         ),
       );
@@ -347,7 +341,7 @@ void main() {
           const Owner7TV(username: 'creator', displayName: 'EmoteCreator'),
           Emote7TVHost(
             '//cdn.7tv.app/emote/owned123',
-            [Emote7TVFile('1x.webp', 32, 32, 'WEBP')],
+            [Emote7TVFile('1x.webp', '1x_static.webp', 32, 32, 'WEBP')],
           ),
         ),
       );
@@ -369,7 +363,7 @@ void main() {
           null, // No owner
           Emote7TVHost(
             '//cdn.7tv.app/emote/noowner123',
-            [Emote7TVFile('1x.webp', 32, 32, 'WEBP')],
+            [Emote7TVFile('1x.webp', '1x_static.webp', 32, 32, 'WEBP')],
           ),
         ),
       );
@@ -392,8 +386,8 @@ void main() {
           Emote7TVHost(
             '//cdn.7tv.app/emote/dim123',
             [
-              Emote7TVFile('1x.webp', 28, 32, 'WEBP'),
-              Emote7TVFile('2x.webp', 56, 64, 'WEBP'),
+              Emote7TVFile('1x.webp', '1x_static.webp', 28, 32, 'WEBP'),
+              Emote7TVFile('2x.webp', '2x_static.webp', 56, 64, 'WEBP'),
             ],
           ),
         ),
@@ -441,8 +435,8 @@ void main() {
           Emote7TVHost(
             '//cdn.7tv.app/emote/avifonly123',
             [
-              Emote7TVFile('1x.avif', 32, 32, 'AVIF'),
-              Emote7TVFile('2x.avif', 64, 64, 'AVIF'),
+              Emote7TVFile('1x.avif', '1x_static.avif', 32, 32, 'AVIF'),
+              Emote7TVFile('2x.avif', '2x_static.avif', 64, 64, 'AVIF'),
             ],
           ),
         ),


### PR DESCRIPTION
Added a new setting under Chat > Emotes and badges to disable emote animations. When enabled, animated emotes from all providers (Twitch, BTTV, FFZ, 7TV) will display as static images instead.

This is useful for users who find animated emotes distracting or experience motion sensitivity.

Closes #472