### PR TITLE
Feat: change emote redirection to third party emote website

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,9 @@ Please follow the local setup and run instructions in the [README](./README.md).
 
 ## Pull request guidelines
 
-When opening a PR, please include what changed, why the change is needed, screenshots / recordings for UI changes.
+When opening a PR, please include what changed, why the change is needed, screenshots / recordings for UI changes (if applicable).
 Please also link the related issue when applicable (for example: Closes #545)
 
 ## Issue guidelines
 
-Please follow the bug report/issue request template.
+Please follow the bug report/feature request template.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing
+
+Thanks for your interest in contributing to Frosty. Contributions of all kinds are welcome, including bug fixes, documentation improvements, feature suggestions, and code changes.
+
+## Before you start
+
+Please take a moment to read the project documentation and check existing issues or pull requests before starting work.
+
+## Development setup
+
+Please follow the local setup and run instructions in the [README](./README.md).
+
+## Pull request guidelines
+
+When opening a PR, please include what changed, why the change is needed, screenshots / recordings for UI changes.
+Please also link the related issue when applicable (for example: Closes #545)
+
+## Issue guidelines
+
+Please follow the bug report/issue request template.

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -271,14 +271,14 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
 
 SPEC CHECKSUMS:
-  advanced_in_app_review: fe8fd50b8670cb3dbe67e4c26ca643f7aea8dbb8
-  app_links: 6d01271b3907b0ee7325c5297c75d697c4226c4d
-  device_info_plus: bf2e3232933866d73fe290f2942f2156cdd10342
+  advanced_in_app_review: daebe4c801525b756fe589de60fd327cb12f965c
+  app_links: a754cbec3c255bd4bbb4d236ecc06f28cd9a7ce8
+  device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
   Firebase: 065f2bb395062046623036d8e6dc857bc2521d56
-  firebase_analytics: b5c909bdc321fab0f9ddf8712f5cef79057e09fa
-  firebase_core: 8f0a8c3aca22e29012e419ee18109b4aa021f777
-  firebase_crashlytics: 4b21fc111f15e814eeab83f90a71efe3c1e9399a
-  firebase_performance: 0a30e8afaae656fdf6fa271ac3c62dc26b74d7a1
+  firebase_analytics: 6903a46192a92993abde88152a14ce1df1c0de2f
+  firebase_core: afac1aac13c931e0401c7e74ed1276112030efab
+  firebase_crashlytics: a316d8dddba772359d93dc38d303ed964579b7a6
+  firebase_performance: a14e0fcd8c20835c2d6a96c6a948c976ba010805
   FirebaseABTesting: a399ffe546392a39b19a5c2fb28bd8ea178a6f47
   FirebaseAnalytics: cd7d01d352f3c237c9a0e31552c257cd0b0c0352
   FirebaseCore: 428912f751178b06bef0a1793effeb4a5e09a9b8
@@ -292,23 +292,23 @@ SPEC CHECKSUMS:
   FirebaseSessions: a2d06fd980431fda934c7a543901aca05fc4edcc
   FirebaseSharedSwift: 9d2fa84a46676302b89dbd5e6e62bce2fe376909
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_native_splash: df59bb2e1421aa0282cb2e95618af4dcb0c56c29
-  flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
+  flutter_native_splash: c32d145d68aeda5502d5f543ee38c192065986cf
+  flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
   GoogleAdsOnDeviceConversion: d68c69dd9581a0f5da02617b6f377e5be483970f
   GoogleAppMeasurement: fce7c1c90640d2f9f5c56771f71deacb2ba3f98c
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  in_app_review: 436034b18594851a7328d7f1c2ed5ec235b79cfc
+  in_app_review: 7dd1ea365263f834b8464673f9df72c80c17c937
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  native_device_orientation: 42487b19c552fb5a6a2b51e61b93366f628113df
-  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
+  native_device_orientation: f3ba5f2ddbab3deee23a5f6693b4f97b02dafea2
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
-  shared_preferences_foundation: 5086985c1d43c5ba4d5e69a4e8083a389e2909e6
-  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
-  url_launcher_ios: bb13df5870e8c4234ca12609d04010a21be43dfa
-  wakelock_plus: 76957ab028e12bfa4e66813c99e46637f367fc7e
-  webview_flutter_wkwebview: 29eb20d43355b48fe7d07113835b9128f84e3af4
+  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+  url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
+  wakelock_plus: e29112ab3ef0b318e58cfa5c32326458be66b556
+  webview_flutter_wkwebview: 8ebf4fded22593026f7dbff1fbff31ea98573c8d
 
 PODFILE CHECKSUM: 57c8aed26fba39d3ec9424816221f294a07c58eb
 


### PR DESCRIPTION
I made the "Open in browser" button redirected to the information page of the emote in third party emote websites like 7tv, bttv, ffz, which is a existing feature of the browser extensions.

Closes #551 

https://github.com/user-attachments/assets/402f8194-b7ce-4a73-8271-8c00b46d420a

