### PR TITLE
make divider line optional

### DIFF
--- a/lib/widgets/draggable_divider.dart
+++ b/lib/widgets/draggable_divider.dart
@@ -141,7 +141,7 @@ class _DraggableDividerState extends State<DraggableDivider> {
             alignment: Alignment.center,
             children: [
               // Background divider line - show only during interaction
-              if (_isDragging || _isHovered)
+              if (widget.showDividerLine && (_isDragging || _isHovered))
                 Center(
                   child: AnimatedContainer(
                     duration: const Duration(milliseconds: 150),


### PR DESCRIPTION
## Fixes
Fixes #466

## Summary
This PR adds a new option to `DraggableDivider` that allows the divider line to be hidden.

Previously, the divider line was shown on hover or drag, which some users found visually distracting in split-screen layouts (video/chat view).

## Changes
- Added `showDividerLine` boolean property to `DraggableDivider`
- Divider line rendering is now gated by:

```dart
if (widget.showDividerLine && (_isDragging || _isHovered))
```