### PR TITLE
fix(video): keep native player alive across rotation

### DIFF
--- a/lib/screens/channel/channel.dart
+++ b/lib/screens/channel/channel.dart
@@ -312,7 +312,14 @@ class _VideoChatState extends State<VideoChat>
     final player = GestureDetector(
       onLongPress: _videoStore.handleToggleOverlay,
       child: _videoStore is NativeVideoStore
-          ? NativeVideo(nativeVideoStore: _videoStore)
+          ? NativeVideo(
+              // GlobalKey so the native platform view is *reparented* (not
+              // rebuilt) across the portrait↔landscape layout swap — without
+              // it, rotating destroys and recreates the player, forcing a
+              // reload. Mirrors the WebView Video below.
+              key: _videoKey,
+              nativeVideoStore: _videoStore,
+            )
           : Video(
               key: _videoKey,
               videoStore: _videoStore as VideoStore,


### PR DESCRIPTION
Rotating the device tore down and recreated the native player's platform view, reloading the stream on every orientation change.

Wrap the player in a `GlobalKey` so the existing platform view is re-parented across the rotation instead of being disposed and rebuilt.

Closes #561
