### PR TITLE
feat(video): low-latency live playback (~9s → ~3s)

### DIFF
--- a/lib/screens/channel/video/native_video_store.dart
+++ b/lib/screens/channel/video/native_video_store.dart
@@ -886,7 +886,7 @@ abstract class NativeVideoStoreBase
     }
     _highLatencyCount = 0;
 
-    final newLatency = '${rounded}s';
+    final newLatency = '${seconds.toStringAsFixed(2)}s';
     if (newLatency != _latency) {
       runInAction(() {
         _latency = newLatency;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -101,9 +101,9 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: frosty-patches
-      resolved-ref: "6460859318b7b44034fe44016cddff02d0bd4c0a"
-      url: "https://github.com/tommyxchow/flutter-native-video-player.git"
+      ref: background-playback
+      resolved-ref: d47ef9adb692fbe99ed4e3a00d9912cfe6b8ce3d
+      url: "https://github.com/francislavoie/flutter-native-video-player.git"
     source: git
     version: "0.4.11"
   boolean_selector:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,8 +78,12 @@ dependencies:
     native_device_orientation: ^2.1.0
     better_native_video_player:
         git:
-            url: https://github.com/tommyxchow/flutter-native-video-player.git
-            ref: frosty-patches
+            # TEMP: points at francislavoie's fork while developing the
+            # background-playback foreground service. Revert to
+            # tommyxchow/flutter-native-video-player @ frosty-patches once the
+            # change is merged upstream. Branch is based on the same pinned ref.
+            url: https://github.com/francislavoie/flutter-native-video-player.git
+            ref: background-playback
 
 dev_dependencies:
     flutter_test:


### PR DESCRIPTION
> **Draft — depends on tommyxchow/flutter-native-video-player#2** (the plugin low-latency work). Can't merge until that lands and a version is published; the pubspec here temporarily points at a fork branch.

Brings native-player live latency from ~9s back down to ~3s, matching desktop. The heavy lifting is in the plugin PR (Twitch prefetch-segment promotion + `TARGETDURATION` reload-cadence fix + low-latency LoadControl). On the app side this bumps the plugin and shows the latency readout to two decimal places for precise feedback.

Closes #573
Related: #418
