### PR TITLE
docs(agents): refresh AGENTS.md after repo audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,6 @@ dart run build_runner build                                         # Regenerate
 dart run build_runner build --delete-conflicting-outputs             # Same, but clears stale outputs
 ```
 
-Before pushing: `flutter analyze && flutter test`.
-
 ## Source Structure
 
 - `lib/apis/` — API services (all extend `BaseApiClient`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,8 @@ dart run build_runner build                                         # Regenerate
 dart run build_runner build --delete-conflicting-outputs             # Same, but clears stale outputs
 ```
 
+Before pushing: `flutter analyze && flutter test`.
+
 ## Source Structure
 
 - `lib/apis/` — API services (all extend `BaseApiClient`)
@@ -54,10 +56,11 @@ dart run build_runner build --delete-conflicting-outputs             # Same, but
 
 - After changing MobX stores or `@JsonSerializable` models, regenerate with `dart run build_runner build`. Never edit `.g.dart` files directly. Commit `.g.dart` files to source control.
 - The secure storage cleanup in `main.dart` looks unnecessary but handles an Android/iOS edge case where secure storage persists after uninstall. Don't remove it.
+- Several deps in `pubspec.yaml` are git-pinned forks carrying compatibility patches (`extended_text_field`, `better_native_video_player`, `simple_pip_mode`). When upgrading dependencies, don't swap them back to pub.dev releases.
 
 ## Testing
 
 - `flutter test` runs all tests; `flutter test test/path/to/file.dart` for a single file
 - HTTP mocking: `http_mock_adapter` (`DioAdapter`) — use full URLs in `onGet`/`onPost`
 - General mocking: `mocktail` (no codegen required)
-- Fixtures live in `test/fixtures/` (e.g., `irc_messages.dart`, `api_responses.dart`)
+- Test layout mirrors `lib/` (`test/apis/`, `test/models/`, `test/screens/`); shared fixtures live in `test/fixtures/` (e.g., `irc_messages.dart`, `api_responses.dart`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,10 +6,8 @@
 
 ## Code Opinions
 
-- Package imports (`import 'package:frosty/...'`), not relative imports
-- Trailing commas always
-- Single quotes
 - Extract related/grouped logic (state, reactions, actions) into dedicated stores when it improves readability — keep widgets focused on rendering
+- Default to writing tests: new or changed logic (stores, API clients, parsing, utils) ships with tests; when touching existing tested code, update or extend its tests. Pure UI/rendering or config changes may skip.
 
 ## Infrastructure Checklist
 
@@ -29,9 +27,9 @@ Flutter mobile app for browsing Twitch on iOS and Android. Uses MobX for state m
 
 ```bash
 flutter pub get                                                     # Install dependencies
-flutter run --dart-define=clientId=ID --dart-define=secret=SECRET   # Run with Twitch credentials
+flutter run --dart-define=CLIENT_ID=ID --dart-define=SECRET=SECRET  # Run with Twitch credentials
 flutter analyze                                                     # Static analysis (run after changes)
-flutter test                                                        # Run tests (if changes touch testable logic)
+flutter test                                                        # Run tests
 dart run build_runner build                                         # Regenerate .g.dart files (MobX/JSON models)
 dart run build_runner build --delete-conflicting-outputs             # Same, but clears stale outputs
 ```


### PR DESCRIPTION
audited every claim in AGENTS.md against the repo and fixed what drifted, then ported a few patterns from my next-template AGENTS.md:

**audit fixes:**
- **fixed wrong dart-define names**: doc said `clientId`/`secret`, but `lib/constants.dart` reads `String.fromEnvironment('CLIENT_ID')` and `('SECRET')` - the documented run command wouldn't have passed credentials at all
- **tests are now the default**: replaced the `(if changes touch testable logic)` escape hatch with a policy bullet - new/changed logic (stores, API clients, parsing, utils) ships with tests; pure UI/config changes may skip
- **dropped lint-enforced style bullets** (package imports, trailing commas, single quotes): all three are already enforced by `analysis_options.yaml`, so repeating them just adds noise

**ported from next-template:**
- **gotcha for git-pinned forks**: `extended_text_field`, `better_native_video_player`, and `simple_pip_mode` carry compatibility patches - a dep upgrade shouldn't swap them back to pub.dev releases
- **test layout**: tests mirror `lib/` (`test/apis/`, `test/models/`, `test/screens/`), pairs with the tests-by-default policy

everything else checked out: source structure dirs, `BaseApiClient`, `auth_store.dart` canonical example, `main.dart` secure-storage gotcha (still at lines 107-123), test fixtures, and mocking deps all verified present.

(a pre-push check line was added then removed - CI gates pushes, and targeted local runs are preferred over full-suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)