### PR TITLE
Fix missing Hype Train emotes

### DIFF
--- a/lib/apis/twitch_api.dart
+++ b/lib/apis/twitch_api.dart
@@ -56,27 +56,44 @@ class TwitchApi extends BaseApiClient {
     }).toList();
   }
 
-  /// Returns a list of Twitch emotes under the provided [setId].
-  Future<List<Emote>> getEmotesSets({required String setId}) async {
-    final data = await get<JsonMap>(
-      '/chat/emotes/set',
-      queryParameters: {'emote_set_id': setId},
-    );
+  /// Returns every Twitch emote the user may use in the broadcaster's chat.
+  Future<List<Emote>> getUserEmotes({
+    required String userId,
+    required String broadcasterId,
+  }) async {
+    final result = <Emote>[];
+    String? cursor;
 
-    final decoded = data['data'] as JsonList;
-    final emotes = decoded.map((emote) => EmoteTwitch.fromJson(emote)).toList();
+    do {
+      final data = await get<JsonMap>(
+        '/chat/emotes/user',
+        queryParameters: {
+          'user_id': userId,
+          'broadcaster_id': broadcasterId,
+          'after': ?cursor,
+        },
+      );
 
-    return emotes.map((emote) {
-      switch (emote.emoteType) {
-        case 'globals':
-        case 'smilies':
-          return Emote.fromTwitch(emote, EmoteType.twitchGlobal);
-        case 'subscriptions':
-          return Emote.fromTwitch(emote, EmoteType.twitchSub);
-        default:
-          return Emote.fromTwitch(emote, EmoteType.twitchUnlocked);
-      }
-    }).toList();
+      final decoded = data['data'] as JsonList;
+      result.addAll(
+        decoded.map((json) {
+          final emote = EmoteTwitch.fromJson(json);
+          switch (emote.emoteType) {
+            case 'globals':
+            case 'smilies':
+              return Emote.fromTwitch(emote, EmoteType.twitchGlobal);
+            case 'subscriptions':
+              return Emote.fromTwitch(emote, EmoteType.twitchSub);
+            default:
+              return Emote.fromTwitch(emote, EmoteType.twitchUnlocked);
+          }
+        }),
+      );
+
+      cursor = (data['pagination'] as JsonMap?)?['cursor'] as String?;
+    } while (cursor != null && cursor.isNotEmpty);
+
+    return result;
   }
 
   /// Returns a map of global Twitch badges to their [Emote] object.

--- a/lib/screens/channel/chat/stores/chat_assets_store.dart
+++ b/lib/screens/channel/chat/stores/chat_assets_store.dart
@@ -404,54 +404,47 @@ abstract class ChatAssetsStoreBase with Store {
 
   @action
   Future<void> userEmotesFuture({
-    required List<String> emoteSets,
-    required Map<String, String> headers,
+    required String userId,
+    required String broadcasterId,
     required Function onError,
   }) async {
-    final userEmotes = await Future.wait(
-      emoteSets.map(
-        (setId) => twitchApi.getEmotesSets(setId: setId).catchError(onError),
-      ),
-    );
+    try {
+      final emotes = await twitchApi.getUserEmotes(
+        userId: userId,
+        broadcasterId: broadcasterId,
+      );
+      final ownerIds = emotes
+          .where((emote) => emote.type == EmoteType.twitchSub)
+          .map((emote) => emote.ownerId)
+          .whereType<String>()
+          .where((ownerId) => ownerId != 'twitch')
+          .toSet();
+      final owners = await Future.wait(
+        ownerIds.map((ownerId) => twitchApi.getUser(id: ownerId)),
+      );
+      final ownerNames = {
+        for (final owner in owners) owner.id: owner.displayName,
+      };
+      final sections = <String, List<Emote>>{};
 
-    for (final emoteSet in userEmotes) {
-      if (emoteSet.isNotEmpty) {
-        if (emoteSet.first.type == EmoteType.twitchSub) {
-          final ownerId = emoteSet.first.ownerId;
-
-          // Check for tuurbo emote sets (e.g., monkey set).
-          if (ownerId == 'twitch') {
-            _userEmoteSectionToEmotes.update(
-              'Global Emotes',
-              (existingEmoteSet) => [...existingEmoteSet, ...emoteSet],
-              ifAbsent: () => emoteSet,
-            );
-          } else {
-            final owner = await twitchApi.getUser(id: ownerId);
-            _userEmoteSectionToEmotes.update(
-              owner.displayName,
-              (existingEmoteSet) => [...existingEmoteSet, ...emoteSet],
-              ifAbsent: () => emoteSet,
-            );
-          }
-        } else if (emoteSet.first.type == EmoteType.twitchGlobal) {
-          _userEmoteSectionToEmotes.update(
-            'Global Emotes',
-            (existingEmoteSet) => [...existingEmoteSet, ...emoteSet],
-            ifAbsent: () => emoteSet,
-          );
-        } else if (emoteSet.first.type == EmoteType.twitchUnlocked) {
-          _userEmoteSectionToEmotes.update(
-            'Unlocked Emotes',
-            (existingEmoteSet) => [...existingEmoteSet, ...emoteSet],
-            ifAbsent: () => emoteSet,
-          );
-        }
-
-        for (final emote in emoteSet) {
-          _userEmoteToObject[emote.name] = emote;
-        }
+      for (final emote in emotes) {
+        final section = switch (emote.type) {
+          EmoteType.twitchGlobal => 'Global Emotes',
+          EmoteType.twitchSub when emote.ownerId == 'twitch' => 'Global Emotes',
+          EmoteType.twitchSub => ownerNames[emote.ownerId] ?? 'Unlocked Emotes',
+          _ => 'Unlocked Emotes',
+        };
+        sections.update(
+          section,
+          (existing) => [...existing, emote],
+          ifAbsent: () => [emote],
+        );
       }
+
+      _userEmoteToObject = {for (final emote in emotes) emote.name: emote};
+      _userEmoteSectionToEmotes = sections;
+    } catch (error) {
+      onError(error);
     }
   }
 

--- a/lib/screens/channel/chat/stores/chat_assets_store.g.dart
+++ b/lib/screens/channel/chat/stores/chat_assets_store.g.dart
@@ -307,14 +307,14 @@ mixin _$ChatAssetsStore on ChatAssetsStoreBase, Store {
 
   @override
   Future<void> userEmotesFuture({
-    required List<String> emoteSets,
-    required Map<String, String> headers,
+    required String userId,
+    required String broadcasterId,
     required Function onError,
   }) {
     return _$userEmotesFutureAsyncAction.run(
       () => super.userEmotesFuture(
-        emoteSets: emoteSets,
-        headers: headers,
+        userId: userId,
+        broadcasterId: broadcasterId,
         onError: onError,
       ),
     );

--- a/lib/screens/channel/chat/stores/chat_store.dart
+++ b/lib/screens/channel/chat/stores/chat_store.dart
@@ -800,14 +800,13 @@ abstract class ChatStoreBase with Store {
             }
             break;
           case Command.globalUserState:
-            final setIds = parsedIRCMessage.tags['emote-sets']?.split(',');
-            if (setIds != null) {
+            final userId = auth.user.details?.id;
+            if (auth.isLoggedIn && userId != null) {
               assetsStore.userEmotesFuture(
-                emoteSets: setIds,
-                headers: auth.headersTwitch,
+                userId: userId,
+                broadcasterId: channelId,
                 onError: (error) {
                   debugPrint(error.toString());
-                  return <Emote>[];
                 },
               );
             }

--- a/lib/utils/twitch_oauth_scopes.dart
+++ b/lib/utils/twitch_oauth_scopes.dart
@@ -9,6 +9,7 @@ const twitchUserScopes = <String>[
   'user:read:blocked_users',
   'user:manage:blocked_users',
   'user:manage:chat_color',
+  'user:read:emotes',
 ];
 
 /// Moderator-only scopes requested via an explicit opt-in upgrade.
@@ -38,6 +39,7 @@ const twitchScopeLabels = <String, String>{
   'user:read:blocked_users': 'View blocked users',
   'user:manage:blocked_users': 'Block and unblock users',
   'user:manage:chat_color': 'Change chat name color',
+  'user:read:emotes': 'View emotes you can use',
   'user:read:moderated_channels': 'View channels you moderate',
   'moderator:manage:chat_messages': 'Delete chat messages as a moderator',
   'moderator:manage:banned_users': 'Timeout and ban users as a moderator',

--- a/test/apis/twitch_api_test.dart
+++ b/test/apis/twitch_api_test.dart
@@ -35,6 +35,63 @@ void main() {
     });
   });
 
+  group('getUserEmotes', () {
+    test('returns every page including Hype Train emotes', () async {
+      dioAdapter.onGet(
+        'https://api.twitch.tv/helix/chat/emotes/user',
+        (server) => server.reply(200, {
+          'data': [
+            {
+              'id': '304420818',
+              'name': 'HypeLol',
+              'emote_type': 'hypetrain',
+              'emote_set_id': '',
+              'owner_id': '477339272',
+            },
+          ],
+          'pagination': {'cursor': 'next-page'},
+        }),
+        queryParameters: {
+          'user_id': '12345',
+          'broadcaster_id': '67890',
+          'first': 100,
+        },
+      );
+      dioAdapter.onGet(
+        'https://api.twitch.tv/helix/chat/emotes/user',
+        (server) => server.reply(200, {
+          'data': [
+            {
+              'id': 'subscriber-1',
+              'name': 'ChannelLove',
+              'emote_type': 'subscriptions',
+              'emote_set_id': 'set-1',
+              'owner_id': '67890',
+            },
+          ],
+          'pagination': <String, dynamic>{},
+        }),
+        queryParameters: {
+          'user_id': '12345',
+          'broadcaster_id': '67890',
+          'first': 100,
+          'after': 'next-page',
+        },
+      );
+
+      final emotes = await api.getUserEmotes(
+        userId: '12345',
+        broadcasterId: '67890',
+      );
+
+      expect(emotes, hasLength(2));
+      expect(emotes[0].name, 'HypeLol');
+      expect(emotes[0].type, EmoteType.twitchUnlocked);
+      expect(emotes[1].name, 'ChannelLove');
+      expect(emotes[1].type, EmoteType.twitchSub);
+    });
+  });
+
   group('getBadgesGlobal', () {
     test('returns map of badge set/version to ChatBadge', () async {
       dioAdapter.onGet(

--- a/test/apis/twitch_api_test.dart
+++ b/test/apis/twitch_api_test.dart
@@ -54,7 +54,6 @@ void main() {
         queryParameters: {
           'user_id': '12345',
           'broadcaster_id': '67890',
-          'first': 100,
         },
       );
       dioAdapter.onGet(
@@ -74,7 +73,6 @@ void main() {
         queryParameters: {
           'user_id': '12345',
           'broadcaster_id': '67890',
-          'first': 100,
           'after': 'next-page',
         },
       );

--- a/test/screens/channel/chat/chat_assets_store_test.dart
+++ b/test/screens/channel/chat/chat_assets_store_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:frosty/apis/bttv_api.dart';
+import 'package:frosty/apis/ffz_api.dart';
+import 'package:frosty/apis/seventv_api.dart';
+import 'package:frosty/apis/twitch_api.dart';
+import 'package:frosty/models/emotes.dart';
+import 'package:frosty/models/user.dart';
+import 'package:frosty/screens/channel/chat/stores/chat_assets_store.dart';
+import 'package:frosty/stores/global_assets_store.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockTwitchApi extends Mock implements TwitchApi {}
+
+class MockBTTVApi extends Mock implements BTTVApi {}
+
+class MockFFZApi extends Mock implements FFZApi {}
+
+class MockSevenTVApi extends Mock implements SevenTVApi {}
+
+class MockGlobalAssetsStore extends Mock implements GlobalAssetsStore {}
+
+void main() {
+  late MockTwitchApi twitchApi;
+  late ChatAssetsStore store;
+
+  const hypeEmote = Emote(
+    name: 'HypeLol',
+    zeroWidth: false,
+    url: 'https://cdn/hype',
+    type: EmoteType.twitchUnlocked,
+    ownerId: 'twitch',
+  );
+  const subEmote = Emote(
+    name: 'ChannelLove',
+    zeroWidth: false,
+    url: 'https://cdn/sub',
+    type: EmoteType.twitchSub,
+    ownerId: '67890',
+  );
+
+  setUp(() {
+    twitchApi = MockTwitchApi();
+    store = ChatAssetsStore(
+      twitchApi: twitchApi,
+      bttvApi: MockBTTVApi(),
+      ffzApi: MockFFZApi(),
+      sevenTVApi: MockSevenTVApi(),
+      globalAssetsStore: MockGlobalAssetsStore(),
+    );
+  });
+
+  test(
+    'indexes Hype Train emotes and preserves subscription sections',
+    () async {
+      when(
+        () => twitchApi.getUserEmotes(userId: '12345', broadcasterId: '67890'),
+      ).thenAnswer((_) async => [hypeEmote, subEmote]);
+      when(() => twitchApi.getUser(id: '67890')).thenAnswer(
+        (_) async => const UserTwitch(
+          '67890',
+          'channel',
+          'Channel',
+          'https://cdn/profile',
+        ),
+      );
+
+      await store.userEmotesFuture(
+        userId: '12345',
+        broadcasterId: '67890',
+        onError: fail,
+      );
+
+      expect(store.userEmoteToObject['HypeLol'], hypeEmote);
+      expect(store.userEmoteSectionToEmotes['Unlocked Emotes'], [hypeEmote]);
+      expect(store.userEmoteSectionToEmotes['Channel'], [subEmote]);
+      verify(() => twitchApi.getUser(id: '67890')).called(1);
+    },
+  );
+
+  test('failed refresh preserves the last complete inventory', () async {
+    when(
+      () => twitchApi.getUserEmotes(userId: '12345', broadcasterId: '67890'),
+    ).thenAnswer((_) async => [hypeEmote]);
+
+    await store.userEmotesFuture(
+      userId: '12345',
+      broadcasterId: '67890',
+      onError: fail,
+    );
+
+    final error = Exception('network failure');
+    when(
+      () => twitchApi.getUserEmotes(userId: '12345', broadcasterId: '67890'),
+    ).thenThrow(error);
+    Object? reportedError;
+
+    await store.userEmotesFuture(
+      userId: '12345',
+      broadcasterId: '67890',
+      onError: (value) => reportedError = value,
+    );
+
+    expect(reportedError, same(error));
+    expect(store.userEmoteToObject, {'HypeLol': hypeEmote});
+    expect(store.userEmoteSectionToEmotes['Unlocked Emotes'], [hypeEmote]);
+  });
+}

--- a/test/utils/twitch_oauth_scopes_test.dart
+++ b/test/utils/twitch_oauth_scopes_test.dart
@@ -9,6 +9,7 @@ void main() {
       }
       expect(twitchAllUserScopes, containsAll(twitchUserScopes));
       expect(twitchAllUserScopes, containsAll(twitchModeratorScopes));
+      expect(twitchUserScopes, contains('user:read:emotes'));
     });
   });
 


### PR DESCRIPTION
Frosty currently builds the user's available Twitch emotes from the emote set IDs sent with `GLOBALUSERSTATE`. Hype Train emotes can have an empty `emote_set_id`, so they aren't included and their names are sent as plain text.

This switches the user emote inventory to Twitch's Get User Emotes endpoint, which includes Hype Train emotes and other emotes the authenticated user can use.

This adds the `user:read:emotes` scope, so existing users may need to sign in again when Frosty first requests their emotes.

Regression coverage was added for the new endpoint and the user emote inventory. The full test suite passes and `flutter analyze` is clean.

I use Frosty on iOS and don't have a way to install a local development build, so I haven't been able to verify the change practically. Note that most of the implementation was done with Codex.

Fixes #352